### PR TITLE
Fixes for TEST LA stage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ OJP-Demo URL: https://opentdatach.github.io/ojp-demo-app/
 
 ----
 
+03.September 2022
+- Fixes for TEST LA stage
+    - limit TripRequest number of results to 1
+    - reload endpoints stop IDs when changing the app stage
+
 27.August 2022
 - Adds full support for mono- / multi- modal journeys - see [#51](https://github.com/openTdataCH/ojp-demo-app-src/issues/51)
 

--- a/src/app/search-form/journey-point-input/journey-point-input.component.html
+++ b/src/app/search-form/journey-point-input/journey-point-input.component.html
@@ -26,7 +26,7 @@
         <sbb-option
           *ngFor="let lookupLocation of lookupLocations; index as idx"
           [value]="idx">
-          {{ computeLocationName(lookupLocation) }}
+          {{ lookupLocation.computeLocationName() }}
         </sbb-option>
       </sbb-autocomplete>
     </div>

--- a/src/app/search-form/journey-point-input/journey-point-input.component.ts
+++ b/src/app/search-form/journey-point-input/journey-point-input.component.ts
@@ -73,18 +73,10 @@ export class JourneyPointInputComponent implements OnInit, OnChanges {
     const optionIdx = ev.option.value;
     const location = this.lookupLocations[optionIdx];
 
-    const inputValue = this.computeLocationName(location);
+    const inputValue = location.computeLocationName();
     this.inputControl.setValue(inputValue);
 
     this.selectedLocation.emit(location);
-  }
-
-  public computeLocationName(location: OJP.Location): string {
-    if (location.stopPlace) {
-      return location.stopPlace.stopPlaceName
-    }
-
-    return location.locationName ?? 'n/a'
   }
 
   private fetchJourneyPoints(searchTerm: string) {

--- a/src/app/search-form/search-form.component.ts
+++ b/src/app/search-form/search-form.component.ts
@@ -1,5 +1,4 @@
 import { Component, OnInit, ViewChild } from '@angular/core';
-import { FormControl, FormGroup } from '@angular/forms';
 
 import { UserTripService } from '../shared/services/user-trip.service'
 import { MapService } from '../shared/services/map.service';

--- a/src/app/search-form/search-form.component.ts
+++ b/src/app/search-form/search-form.component.ts
@@ -166,6 +166,8 @@ export class SearchFormComponent implements OnInit {
   onChangeStageAPI(ev: SbbRadioChange) {
     const newAppStage = ev.value as OJP.APP_Stage
     this.userTripService.updateAppStage(newAppStage)
+
+    this.userTripService.refetchEndpointsByName();
   }
 
   onChangeDateTime() {

--- a/src/app/shared/ojp-sdk/location/geoposition-bbox.ts
+++ b/src/app/shared/ojp-sdk/location/geoposition-bbox.ts
@@ -20,6 +20,19 @@ export class GeoPositionBBOX {
     this.northEast = new GeoPosition(maxLongitude, maxLatitude);
   }
 
+  public static initFromGeoPosition(geoPosition: GeoPosition, width_x_meters: number, width_y_meters: number): GeoPositionBBOX {
+    // 7612m for 0.1deg long - for Switzerland, latitude 46.8
+    // 11119m for 0.1deg lat
+    const spanLongitude = width_x_meters * 0.1 / 7612;
+    const spanLatitude = width_y_meters * 0.1 / 11119;
+
+    const southWest = new GeoPosition(geoPosition.longitude - spanLongitude / 2, geoPosition.latitude - spanLatitude / 2);
+    const northEast = new GeoPosition(geoPosition.longitude + spanLongitude / 2, geoPosition.latitude + spanLatitude / 2);
+
+    const bbox = new GeoPositionBBOX([southWest, northEast]);
+    return bbox;
+  }
+
   extend(geoPositions: GeoPosition | GeoPosition[]) {
     if (!Array.isArray(geoPositions)) {
       geoPositions = [geoPositions];

--- a/src/app/shared/ojp-sdk/location/location.ts
+++ b/src/app/shared/ojp-sdk/location/location.ts
@@ -4,6 +4,11 @@ import { StopPlace } from "./stopplace";
 import { Address } from "./address";
 import { PointOfInterest } from "./poi";
 
+interface NearbyLocation {
+  distance: number
+  location: Location
+}
+
 export class Location {
   public address: Address | null
   public stopPointRef: string | null
@@ -168,5 +173,31 @@ export class Location {
     }
 
     return this.locationName ?? null;
+  }
+
+  public findClosestLocation(otherLocations: Location[]): NearbyLocation | null {
+    const geoPositionA = this.geoPosition;
+    if (geoPositionA === null) {
+      return null;
+    }
+
+    let closestLocation: NearbyLocation | null = null;
+
+    otherLocations.forEach(locationB => {
+      const geoPositionB = locationB.geoPosition;
+      if (geoPositionB === null) {
+        return;
+      }
+
+      const dAB = geoPositionA.distanceFrom(geoPositionB);
+      if ((closestLocation === null) || (dAB < closestLocation.distance)) {
+        closestLocation = {
+          location: locationB,
+          distance: dAB
+        }
+      }
+    });
+
+    return closestLocation;
   }
 }

--- a/src/app/shared/ojp-sdk/location/location.ts
+++ b/src/app/shared/ojp-sdk/location/location.ts
@@ -161,4 +161,12 @@ export class Location {
 
     return feature
   }
+
+  public computeLocationName(): string | null {
+    if (this.stopPlace) {
+      return this.stopPlace.stopPlaceName;
+    }
+
+    return this.locationName ?? null;
+  }
 }

--- a/src/app/shared/ojp-sdk/request/trips-request/trips-request.ts
+++ b/src/app/shared/ojp-sdk/request/trips-request/trips-request.ts
@@ -84,7 +84,11 @@ export class TripRequest extends OJPBaseRequest {
 
     const paramsNode = tripRequestNode.ele('ojp:Params');
 
-    const numberOfResults = 5;
+    let numberOfResults = 5;
+    if (this.stageConfig.key === 'TEST LA') {
+      numberOfResults = 1;
+    }
+
     paramsNode.ele('ojp:NumberOfResults', numberOfResults);
 
     paramsNode.ele('ojp:IncludeTrackSections', true)

--- a/src/index.html
+++ b/src/index.html
@@ -42,7 +42,7 @@
             © <a href="https://opentransportdata.swiss/en/" target="_blank">Open-Data-Plattform Mobilität Schweiz</a> 2021 - 2022
           </div>
           <div>
-            Last Update: <a href="https://github.com/openTdataCH/ojp-demo-app-src/blob/main/CHANGELOG.md" target="_blank">27.August 2022 - v20220827.1</a>
+            Last Update: <a href="https://github.com/openTdataCH/ojp-demo-app-src/blob/main/CHANGELOG.md" target="_blank">03.September 2022 - v20220903.1</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
- limits the number of results to 1 for "TEST LA" TripRequest requests
- refresh the endpoint locations when changing the stages because the stop ids are different