### PR TITLE
Feature: Improve TripRequest requests for monomodal journeys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ OJP-Demo URL: https://opentdatach.github.io/ojp-demo-app/
     - moved the map layers legend on top-right of the map
     - adds custom POI icons based on category/subcategory
     - enable multiple POI categories via `LocationInformationRequest` requests
+- Improve `OJP:TripRequest` requests for monomodal journeys - [#PR 62](https://github.com/openTdataCH/ojp-demo-app-src/pull/62)
+    - Use `<ojp:NumberOfResults>0</ojp:NumberOfResults>` when monomodal and custom modes are enabled
 
 18.September 2022
 - Station Board Tab - see [#49](https://github.com/openTdataCH/ojp-demo-app-src/issues/49), [#PR 60](https://github.com/openTdataCH/ojp-demo-app-src/pull/60)

--- a/src/app/shared/ojp-sdk/request/trips-request/trips-request.ts
+++ b/src/app/shared/ojp-sdk/request/trips-request/trips-request.ts
@@ -84,11 +84,7 @@ export class TripRequest extends OJPBaseRequest {
 
     const paramsNode = tripRequestNode.ele('ojp:Params');
 
-    let numberOfResults = 5;
-    if (this.stageConfig.key === 'TEST LA') {
-      numberOfResults = 1;
-    }
-
+    const numberOfResults = this.computeNumberOfResultsParam();
     paramsNode.ele('ojp:NumberOfResults', numberOfResults);
 
     paramsNode.ele('ojp:IncludeTrackSections', true)
@@ -145,5 +141,21 @@ export class TripRequest extends OJPBaseRequest {
         }
       });
     }
+  }
+
+  private computeNumberOfResultsParam(): number {
+    if (this.stageConfig.key === 'TEST LA') {
+      return 1;
+    }
+
+    if (this.requestParams.modeType === 'monomodal') {
+      const customModes: IndividualTransportMode[] = ['walking', 'cycle', 'car_self_driving', 'bicycle_rental', 'escooter_rental', 'car_sharing'];
+      const isCustomMode = customModes.indexOf(this.requestParams.transportMode) !== -1;
+      if (isCustomMode) {
+        return 0;
+      }
+    }
+
+    return 5;
   }
 }


### PR DESCRIPTION
Use `<ojp:NumberOfResults>0</ojp:NumberOfResults>` when monomodal and custom modes are enabled