### PR TITLE
Fix permalinks with coordinates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ OJP-Demo URL: https://opentdatach.github.io/ojp-demo-app/
 
 28.October 2023
 - use latest [OJP JS](https://github.com/openTdataCH/ojp-js) version
-- fix handling of coordinates in permalinks
+- fix handling of coordinates in permalinks - [PR #118](https://github.com/openTdataCH/ojp-demo-app-src/pull/118)
 
 15.October 2023
 - use latest [OJP JS](https://github.com/openTdataCH/ojp-js) version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ OJP-Demo URL: https://opentdatach.github.io/ojp-demo-app/
 
 ----
 
+28.October 2023
+- use latest [OJP JS](https://github.com/openTdataCH/ojp-js) version
+- fix handling of coordinates in permalinks
+
 15.October 2023
 - use latest [OJP JS](https://github.com/openTdataCH/ojp-js) version
 - add [SIRI-SX](https://opentransportdata.swiss/en/siri-sx/) messages in station board - [displaying situations on the station board #7](https://github.com/openTdataCH/ojp-demo-app/issues/7), [PR #117](https://github.com/openTdataCH/ojp-demo-app-src/pull/117)

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "rxjs": "~7.5.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.11.4",
-    "ojp-sdk": "0.9.19"
+    "ojp-sdk": "0.9.20"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^14.0.6",

--- a/src/app/search-form/journey-point-input/journey-point-input.component.ts
+++ b/src/app/search-form/journey-point-input/journey-point-input.component.ts
@@ -74,7 +74,6 @@ export class JourneyPointInputComponent implements OnInit, OnChanges {
 
       const coordsLocation = OJP.Location.initFromLiteralCoords(searchTerm);
       if (coordsLocation) {
-        
         this.resetMapLocations()
         
         this.handleCoordsPick(coordsLocation)

--- a/src/app/shared/components/web-footer.html
+++ b/src/app/shared/components/web-footer.html
@@ -123,7 +123,7 @@
         © <a href="https://opentransportdata.swiss/en/" target="_blank">Open-Data-Plattform Mobilität Schweiz</a> 2021 - 2023
       </div>
       <div>
-        Last Update: <a href="https://github.com/openTdataCH/ojp-demo-app-src/blob/main/CHANGELOG.md" target="_blank">15.October 2023</a>
+        Last Update: <a href="https://github.com/openTdataCH/ojp-demo-app-src/blob/main/CHANGELOG.md" target="_blank">28.October 2023</a>
       </div>
     </div>
   </div>

--- a/src/app/shared/services/user-trip.service.ts
+++ b/src/app/shared/services/user-trip.service.ts
@@ -400,9 +400,10 @@ export class UserTripService {
       } else {
         let geoPositionLngLatS = tripLocationPoint?.location.geoPosition?.asLatLngString(true) ?? null
         if (geoPositionLngLatS) {
-          const locatioName = tripLocationPoint?.location.computeLocationName();
-          if (locatioName) {
-            geoPositionLngLatS = locatioName + '(' + geoPositionLngLatS + ')'
+          const includeLiteralCoords = false;
+          const locationName = tripLocationPoint?.location.computeLocationName(includeLiteralCoords);
+          if (locationName) {
+            geoPositionLngLatS = geoPositionLngLatS + '(' + locationName + ')'
           }
 
           queryParams.append(queryParamKey, geoPositionLngLatS)

--- a/src/app/shared/services/user-trip.service.ts
+++ b/src/app/shared/services/user-trip.service.ts
@@ -98,6 +98,7 @@ export class UserTripService {
       }
 
       const coordsLocation = OJP.Location.initFromLiteralCoords(stopPlaceRef);
+
       if (coordsLocation) {
         const coordsPromise = new Promise<OJP.Location[]>((resolve, reject) => {
           resolve([coordsLocation]);
@@ -405,7 +406,6 @@ export class UserTripService {
           }
 
           queryParams.append(queryParamKey, geoPositionLngLatS)
-          
         }
       }
     })


### PR DESCRIPTION
- [Make sure location name doesnt contain coords literals for permalinks](https://github.com/openTdataCH/ojp-demo-app-src/commit/4bbe8947ede63facafb544e67b5aae351c92ce9b)
Example: https://tools.odpch.ch/beta-ojp-demo/search?from=46.938522,7.445941(Location%20A)&to=46.933911,7.444883(Location%20B)