### PR TITLE
Feature: Load TripRequest XML from a Github gist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ OJP-Demo URL: https://opentdatach.github.io/ojp-demo-app/
 - use `0.9.33` version of [OJP JS](https://github.com/openTdataCH/ojp-js) SDK
 - adapt the LIR requests for the new API - [Fix restriction types #136](https://github.com/openTdataCH/ojp-demo-app-src/pull/136)
 - adds support for car shuttle train (Autoverladezug) - [Feature: Car shuttle train #137](https://github.com/openTdataCH/ojp-demo-app-src/pull/137)
+- adds support for loading TR Response XML from external gists - [Load TripRequest XML from a Github gist #138](https://github.com/openTdataCH/ojp-demo-app-src/pull/138)
 
 24.March 2024
 - use `0.9.32` version of [OJP JS](https://github.com/openTdataCH/ojp-js) SDK

--- a/src/app/search-form/search-form.component.ts
+++ b/src/app/search-form/search-form.component.ts
@@ -118,6 +118,12 @@ export class SearchFormComponent implements OnInit {
     if (this.useMocks) {
       this.initLocationsFromMocks()
     }
+
+    const queryParams = new URLSearchParams(document.location.search);
+    const gistId = queryParams.get('gist');
+    if (gistId) {
+      this.initFromGistRef(gistId);
+    }
   }
 
   private updateLocationTexts() {
@@ -166,6 +172,10 @@ export class SearchFormComponent implements OnInit {
     const mockURL = '/path/to/mock';
 
     const mockText = await (await fetch(mockURL)).text();
+    this.initFromMockXML(mockText);
+  }
+
+  private async initFromMockXML(mockText: string) {
     const request = OJP.TripRequest.initWithResponseMock(mockText);
     request.fetchResponseWithCallback((response) => {
       if (response.message === 'TripRequest.TripsNo') {
@@ -181,6 +191,29 @@ export class SearchFormComponent implements OnInit {
         this.handleCustomTripResponse(response.trips);
       }
     });
+  }
+
+  private async initFromGistRef(gistId: string) {
+    const gistURLMatches = gistId.match(/https:\/\/gist.github.com\/[^\/]+?\/([0-9a-z]*)/);
+    if (gistURLMatches) {
+      gistId = gistURLMatches[1];
+    }
+
+    const gistAPI = 'https://api.github.com/gists/' + gistId;
+    const gistJSON = await (await fetch(gistAPI)).json();
+    const gistFiles = gistJSON['files'] as Record<string, any>;
+
+    for (const gistFile in gistFiles) {
+      const gistFileData = gistFiles[gistFile];
+      if (gistFileData['language'] !== 'XML') {
+        continue;
+      }
+
+      const mockText = gistFileData['content'];
+      this.initFromMockXML(mockText);
+
+      break;
+    }
   }
 
   onLocationSelected(location: OJP.Location | null, originType: OJP.JourneyPointType) {


### PR DESCRIPTION
For instance following XML
https://gist.github.com/vasile/61a6817b61c25796883401ece11654f0

Can be loaded and using the gist ref
https://opentdatach.github.io/ojp-demo-app/search?gist=61a6817b61c25796883401ece11654f0

<img height="500" alt="image" src="https://github.com/openTdataCH/ojp-demo-app-src/assets/113994/c3b1acf5-0530-428d-9df0-a5bd3bbb7ad6">
