### PR TITLE
Updates situations/traffic/real-time info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ OJP-Demo URL: https://opentdatach.github.io/ojp-demo-app/
 
 ----
 
+27.August 2024
+- Updates situations/traffic/real-time info [PR #155](https://github.com/openTdataCH/ojp-demo-app-src/pull/155)
+  - use `0.10.1` version of [ojp-js](https://github.com/openTdataCH/ojp-js) SDK
+  - allow to display SIRI-SX situations with multiple descriptions
+  - adds support for trips with `Cancelled`, `Infeasable` Trip status
+  - adds support for `NotServicedStopa property for TimedLeg stops
+  - move the logic for `StationBoardModel` from the SDK into the GUI
+
 26.August 2024
 - display service trip info in a popover / standalone tab - [PR #154](https://github.com/openTdataCH/ojp-demo-app-src/pull/154)
 - paginate results, display prev / next connections - [PR #153](https://github.com/openTdataCH/ojp-demo-app-src/pull/153) 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "rxjs": "~7.5.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.11.4",
-    "ojp-sdk": "0.9.36"
+    "ojp-sdk": "0.10.1"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^14.0.6",

--- a/src/app/helpers/ojp-helpers.ts
+++ b/src/app/helpers/ojp-helpers.ts
@@ -1,6 +1,7 @@
 import * as OJP from 'ojp-sdk';
 
 import { LegStopPointData } from '../shared/components/service-stops.component';
+import { SituationData } from '../shared/types/situation-type';
 
 export class OJPHelpers {
   public static computeIconFilenameForService(service: OJP.JourneyService): string {
@@ -92,5 +93,26 @@ export class OJPHelpers {
     stopPointData.geoPosition = stopPoint.location.geoPosition;
 
     stopPointData.isNotServicedStop = stopPoint.isNotServicedStop === true;
+  }
+
+  public static computeSituationsData(siriSituations: OJP.PtSituationElement[]): SituationData[] {
+    const situationsData: SituationData[] = [];
+
+    siriSituations.forEach(situation => {
+      const situationContentV1 = situation.situationContentV1;
+      if (situationContentV1 === null) {
+        return;
+      }
+
+      const situationData: SituationData = {
+        summary: situationContentV1.summary,
+        descriptions: situationContentV1.descriptions,
+        details: situationContentV1.details
+      }
+
+      situationsData.push(situationData);
+    });
+
+    return situationsData;
   }
 }

--- a/src/app/helpers/ojp-helpers.ts
+++ b/src/app/helpers/ojp-helpers.ts
@@ -90,5 +90,7 @@ export class OJPHelpers {
     }
 
     stopPointData.geoPosition = stopPoint.location.geoPosition;
+
+    stopPointData.isNotServicedStop = stopPoint.isNotServicedStop === true;
   }
 }

--- a/src/app/journey/journey-result-row/journey-result-row.component.html
+++ b/src/app/journey/journey-result-row/journey-result-row.component.html
@@ -4,7 +4,18 @@
   <sbb-expansion-panel-header>
     <div class="d-flex justify-content-between w-100 trip-info">
       <div>
-        <div class="trip-info-header">{{ this.tripHeaderStats.title }} - {{ this.tripHeaderStats.tripChangesInfo }}</div>
+        <div class="trip-info-header d-flex gap-1">
+          <div>{{ this.tripHeaderStats.title }}</div>
+          <div *ngIf="this.tripHeaderStats.isCancelled === true">
+            <span class="badge rounded-pill bg-danger fw-bolder">Cancelled</span>
+          </div>
+          <div *ngIf="this.tripHeaderStats.isInfeasable === true">
+            <span class="badge rounded-pill bg-warning fw-bolder text-dark">Infeasable</span>
+          </div>
+          <div>
+            <span> - {{ this.tripHeaderStats.tripChangesInfo }}</span>
+          </div>
+        </div>
         <div>{{ this.tripHeaderStats.tripDurationS }} - {{ this.tripHeaderStats.tripDistanceS }}</div>
       </div>
       <div class="trip-info-header">

--- a/src/app/journey/journey-result-row/journey-result-row.component.ts
+++ b/src/app/journey/journey-result-row/journey-result-row.component.ts
@@ -11,6 +11,9 @@ interface TripHeaderStats {
   tripToTime: string,
   tripDurationS: string,
   tripDistanceS: string,
+
+  isCancelled: boolean,
+  isInfeasable: boolean
 }
 
 @Component({
@@ -49,7 +52,10 @@ export class JourneyResultRowComponent implements OnInit {
   }
 
   private initTripHeaderStats(trip: OJP.Trip) {
-    this.tripHeaderStats.title = 'Trip ' + ((this.idx ?? 0) + 1)
+    this.tripHeaderStats.title = 'Trip ' + ((this.idx ?? 0) + 1);
+
+    this.tripHeaderStats.isCancelled = trip.stats.isCancelled === true;
+    this.tripHeaderStats.isInfeasable = trip.stats.isInfeasable === true;
       
     if (trip.stats.transferNo === 0) {
       this.tripHeaderStats.tripChangesInfo = 'direct'

--- a/src/app/journey/journey-result-row/result-trip-leg/result-trip-leg.component.html
+++ b/src/app/journey/journey-result-row/result-trip-leg/result-trip-leg.component.html
@@ -212,9 +212,26 @@
           <p>
             <strong>{{ situation.situationContent.summary }}</strong>
           </p>
-          <div>
-            {{ situation.situationContent.description }}
-          </div>
+
+          <!-- Handle situations with one-description -->
+          <ng-container *ngIf="situation.situationContent.descriptions.length === 1">
+            <div>
+              {{ situation.situationContent.descriptions[0] }}
+            </div>
+          </ng-container>
+
+          <!-- Handle situations with 2 or more descriptions -->
+          <ng-container *ngIf="situation.situationContent.descriptions.length > 1">
+            <ul class="tooltip-list">
+              <li *ngFor="let descriptionText of situation.situationContent.descriptions">
+                {{ descriptionText }}
+              </li>
+            </ul>
+
+            <!-- => insert a delimiter between description and detail -->
+            <h6>Detail</h6>
+          </ng-container>
+          
           <ul class="tooltip-list">
             <li *ngFor="let detailText of situation.situationContent.details">
               {{ detailText }}

--- a/src/app/journey/journey-result-row/result-trip-leg/result-trip-leg.component.html
+++ b/src/app/journey/journey-result-row/result-trip-leg/result-trip-leg.component.html
@@ -62,6 +62,7 @@
           </div>
         </div>
       </div>
+      <div *ngIf="this.legInfoDataModel.fromLocationData.isNotServicedStop"><span class="badge rounded-pill bg-danger fw-bolder">not serviced</span></div>
     </div>
 
     <div 
@@ -70,7 +71,10 @@
         class="leg-platform-assistance" 
         src="{{ this.legInfoDataModel.fromLocationData.platformAssistanceIconPath }}" 
         title="{{ this.legInfoDataModel.fromLocationData.platformAssistanceTooltip }}" />
-      <span>{{ this.legInfoDataModel.fromLocationData.depText }}</span>
+      
+      <span *ngIf="!this.legInfoDataModel.fromLocationData.isNotServicedStop">{{ this.legInfoDataModel.fromLocationData.depText }}</span>
+      <span *ngIf="this.legInfoDataModel.fromLocationData.isNotServicedStop"><del>{{ this.legInfoDataModel.fromLocationData.depText }}</del></span>
+      
       <span class="time-delay">{{ this.legInfoDataModel.fromLocationData.depDelayText }}</span>
     </div>
   </div>
@@ -103,6 +107,7 @@
           </div>
         </div>
       </div>
+      <div *ngIf="this.legInfoDataModel.toLocationData.isNotServicedStop"><span class="badge rounded-pill bg-danger fw-bolder">not serviced</span></div>
     </div>
     
     <div 
@@ -111,7 +116,10 @@
         class="leg-platform-assistance" 
         src="{{ this.legInfoDataModel.toLocationData.platformAssistanceIconPath }}" 
         title="{{ this.legInfoDataModel.toLocationData.platformAssistanceTooltip }}" />
-      <span>{{ this.legInfoDataModel.toLocationData.arrText }}</span>
+      
+      <span *ngIf="!this.legInfoDataModel.toLocationData.isNotServicedStop">{{ this.legInfoDataModel.toLocationData.arrText }}</span>
+      <span *ngIf="this.legInfoDataModel.toLocationData.isNotServicedStop"><del>{{ this.legInfoDataModel.toLocationData.arrText }}</del></span>
+      
       <span class="time-delay">{{ this.legInfoDataModel.toLocationData.arrDelayText }}</span>
     </div>
   </div>
@@ -228,22 +236,25 @@
   </div>
 
   <div class="py-2 collapse" [id]="this.legElementId">
-    <div class="d-flex gap-2">
-      <div class="flex-grow-1">
-        <div *ngFor="let locationData of this.legInfoDataModel.intermediaryLocationsData">
-          {{ locationData.locationText }}
-        </div>
-      </div>
-      <div>
-        <div *ngFor="let locationData of this.legInfoDataModel.intermediaryLocationsData">
-          <div>{{ locationData.arrText ?? ' ' }} <span class="time-delay">{{ locationData.arrDelayText }}</span></div>
-        </div>
-      </div>
-      <div>
-        <div *ngFor="let locationData of this.legInfoDataModel.intermediaryLocationsData">
-          {{ locationData.depText }} <span class="time-delay">{{ locationData.depDelayText }}</span>
-        </div>
-      </div>
-    </div>
+    <table class="table table-hover table-stops mb-0 align-middle">
+      <tbody>
+        <tr *ngFor="let locationData of this.legInfoDataModel.intermediaryLocationsData">
+          <td>
+            <div class="d-flex gap-2">
+              <div>{{ locationData.locationText }}</div>
+              <div *ngIf="locationData.isNotServicedStop"><span class="badge rounded-pill bg-danger fw-bolder">not serviced</span></div>
+            </div>
+          </td>
+          <td class="fit">
+            <div *ngIf="!locationData.isNotServicedStop">{{ locationData.arrText ?? ' ' }} <span class="time-delay">{{ locationData.arrDelayText }}</span></div>
+            <div *ngIf="locationData.isNotServicedStop"><del>{{ locationData.arrText ?? ' ' }}</del> <span class="time-delay">{{ locationData.arrDelayText }}</span></div>
+          </td>
+          <td class="fit stop-time">
+            <div *ngIf="!locationData.isNotServicedStop">{{ locationData.depText }} <span class="time-delay">{{ locationData.depDelayText }}</span></div>
+            <div *ngIf="locationData.isNotServicedStop"><del>{{ locationData.depText }}</del> <span class="time-delay">{{ locationData.depDelayText }}</span></div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </div>
 </ng-template>

--- a/src/app/journey/journey-result-row/result-trip-leg/result-trip-leg.component.html
+++ b/src/app/journey/journey-result-row/result-trip-leg/result-trip-leg.component.html
@@ -221,9 +221,26 @@
             <p>
               <strong>{{ situationData.summary }}</strong>
             </p>
-            <div>
-              {{ situationData.description }}
-            </div>
+
+            <!-- Handle situations with one-description -->
+            <ng-container *ngIf="situationData.descriptions.length === 1">
+              <div>
+                {{ situationData.descriptions[0] }}
+              </div>
+            </ng-container>
+
+            <!-- Handle situations with 2 or more descriptions -->
+            <ng-container *ngIf="situationData.descriptions.length > 1">
+              <ul class="tooltip-list">
+                <li *ngFor="let descriptionText of situationData.descriptions">
+                  {{ descriptionText }}
+                </li>
+              </ul>
+            
+              <!-- => insert a delimiter between description and detail -->
+              <h6>Detail</h6>
+            </ng-container>
+            
             <ul class="tooltip-list">
               <li *ngFor="let detailText of situationData.details">
                 {{ detailText }}

--- a/src/app/journey/journey-result-row/result-trip-leg/result-trip-leg.component.html
+++ b/src/app/journey/journey-result-row/result-trip-leg/result-trip-leg.component.html
@@ -207,38 +207,23 @@
     </div>
 
     <div class="mt-2" *ngIf="this.legInfoDataModel.hasSituations">
-      <sbb-tooltip svgIcon="fpl:info" *ngIf="this.legInfoDataModel.hasSituations">
-        <div *ngFor="let situation of this.legInfoDataModel.situations; index as idx">
-          <p>
-            <strong>{{ situation.situationContent.summary }}</strong>
-          </p>
-
-          <!-- Handle situations with one-description -->
-          <ng-container *ngIf="situation.situationContent.descriptions.length === 1">
+      <div class="d-flex gap-2">
+        <div *ngFor="let situationData of this.legInfoDataModel.situations">
+          <sbb-tooltip svgIcon="fpl:info">
+            <p>
+              <strong>{{ situationData.summary }}</strong>
+            </p>
             <div>
-              {{ situation.situationContent.descriptions[0] }}
+              {{ situationData.description }}
             </div>
-          </ng-container>
-
-          <!-- Handle situations with 2 or more descriptions -->
-          <ng-container *ngIf="situation.situationContent.descriptions.length > 1">
             <ul class="tooltip-list">
-              <li *ngFor="let descriptionText of situation.situationContent.descriptions">
-                {{ descriptionText }}
+              <li *ngFor="let detailText of situationData.details">
+                {{ detailText }}
               </li>
             </ul>
-
-            <!-- => insert a delimiter between description and detail -->
-            <h6>Detail</h6>
-          </ng-container>
-          
-          <ul class="tooltip-list">
-            <li *ngFor="let detailText of situation.situationContent.details">
-              {{ detailText }}
-            </li>
-          </ul>
+          </sbb-tooltip>
         </div>
-      </sbb-tooltip>
+      </div>
     </div>
   </div>
 

--- a/src/app/journey/journey-result-row/result-trip-leg/result-trip-leg.component.scss
+++ b/src/app/journey/journey-result-row/result-trip-leg/result-trip-leg.component.scss
@@ -79,3 +79,13 @@
 .intermediary-stops {
   font-size: 14px;
 }
+
+.table-stops {
+  font-size: 13px;
+}
+
+.table-stops td.fit, 
+.table-stops th.fit {
+  white-space: nowrap;
+  width: 1%;
+}

--- a/src/app/journey/journey-result-row/result-trip-leg/result-trip-leg.component.ts
+++ b/src/app/journey/journey-result-row/result-trip-leg/result-trip-leg.component.ts
@@ -10,18 +10,13 @@ import { MapService } from '../../../shared/services/map.service'
 import { OJPHelpers } from '../../../helpers/ojp-helpers';
 import { LegStopPointData } from '../../../shared/components/service-stops.component'
 import { TripInfoResultPopoverComponent } from './trip-info-result-popover/trip-info-result-popover.component';
+import { SituationData } from '../../../shared/types/situation-type';
 
 type LegTemplate = 'walk' | 'timed' | 'taxi';
 
 type ServiceAttributeRenderModel = {
   icon: string,
   caption: string
-}
-
-interface SituationData {
-  summary: string
-  description: string
-  details: string[]
 }
 
 interface LegInfoDataModel {
@@ -339,33 +334,7 @@ export class ResultTripLegComponent implements OnInit {
       }
 
       const timedLeg = leg as OJP.TripTimedLeg;
-      timedLeg.service.siriSituations.forEach(situation => {
-        situation.publishingActions.forEach(publishingAction => {
-          const mapTextualContent = publishingAction.passengerInformation.mapTextualContent;
-
-          const situationData = <SituationData>{};
-
-          if ('Summary' in mapTextualContent) {
-            situationData.summary = mapTextualContent['Summary'].join('. ');
-          }
-
-          if ('Description' in mapTextualContent) {
-            situationData.description = mapTextualContent['Description'].join('. ');
-          }
-
-          situationData.details = [];
-          const detailKeys = ['Consequence', 'Duration', 'Reason', 'Recommendation', 'Remark'];
-          detailKeys.forEach(detailKey => {
-            if (detailKey in mapTextualContent) {
-              situationData.details = situationData.details.concat(mapTextualContent[detailKey]);
-            }
-          });
-
-          situationsData.push(situationData);
-        });
-      });
-
-      return situationsData;
+      return OJPHelpers.computeSituationsData(timedLeg.service.siriSituations);
     })();
     this.legInfoDataModel.hasSituations = this.legInfoDataModel.situations.length > 0;
 

--- a/src/app/journey/journey-result-row/result-trip-leg/result-trip-leg.component.ts
+++ b/src/app/journey/journey-result-row/result-trip-leg/result-trip-leg.component.ts
@@ -269,15 +269,17 @@ export class ResultTripLegComponent implements OnInit {
     this.legInfoDataModel.isWalking = isWalking;
 
     this.legInfoDataModel.legTemplate = (() => {
-      const defaultLegTemplate: LegTemplate = 'timed';
-      if (isWalking) {
-        return 'walk';
-      }
+      const defaultLegTemplate: LegTemplate = 'walk';
+      
       if (isContinous) {
         const continousLeg = leg as OJP.TripContinousLeg;
         if (continousLeg.isTaxi()) {
           return 'taxi';
         }
+      }
+
+      if (leg.legType === 'TimedLeg') {
+        return 'timed';
       }
       
       return defaultLegTemplate;

--- a/src/app/search-form/journey-point-input/journey-point-input.component.ts
+++ b/src/app/search-form/journey-point-input/journey-point-input.component.ts
@@ -68,7 +68,7 @@ export class JourneyPointInputComponent implements OnInit, OnChanges {
         return;
       }
 
-      if (searchTerm.length < 2) {
+      if (searchTerm.length < 1) {
         return;
       }
 

--- a/src/app/shared/components/service-stops.component.ts
+++ b/src/app/shared/components/service-stops.component.ts
@@ -17,6 +17,8 @@ export interface LegStopPointData {
   platformAssistanceTooltip: string,
 
   geoPosition: OJP.GeoPosition | null
+
+  isNotServicedStop: boolean
 }
 
 @Component({

--- a/src/app/shared/components/web-footer.ts
+++ b/src/app/shared/components/web-footer.ts
@@ -17,7 +17,7 @@ export class WebFooterComponent implements OnInit {
   constructor() {
     this.model = {
       sdkVersion: OJP.SDK_VERSION,
-      lastUpdate: '26.August 2024',
+      lastUpdate: '27.August 2024',
     }
   }
 

--- a/src/app/shared/types/situation-type.ts
+++ b/src/app/shared/types/situation-type.ts
@@ -1,0 +1,5 @@
+export interface SituationData {
+  summary: string
+  descriptions: string[]
+  details: string[]
+}

--- a/src/app/station-board/result/station-board-result.component.html
+++ b/src/app/station-board/result/station-board-result.component.html
@@ -39,23 +39,23 @@
             <div class="departure-delay">{{ formatStopEventTime(stopEntry, 'stopDelayText') }}</div>
           </div>
           <div *ngIf="hasSituations(stopEntry)">
-            <sbb-tooltip svgIcon="fpl:info">
-              <div *ngFor="let situation of stopEntry.stopSituations; index as idx">
-                <p>
-                  <strong>{{ situation.situationContent.summary }}</strong>
-                </p>
-                <ul class="tooltip-list">
-                  <li *ngFor="let descriptionText of situation.situationContent.descriptions">
-                    {{ descriptionText }}
-                  </li>
-                </ul>
-                <ul class="tooltip-list">
-                  <li *ngFor="let detailText of situation.situationContent.details">
-                    {{ detailText }}
-                  </li>
-                </ul>
+            <div class="d-flex gap-2">
+              <div *ngFor="let situationData of stopEntry.stopSituations">
+                <sbb-tooltip svgIcon="fpl:info">
+                  <p>
+                    <strong>{{ situationData.summary }}</strong>
+                  </p>
+                  <div>
+                    {{ situationData.description }}
+                  </div>
+                  <ul class="tooltip-list">
+                    <li *ngFor="let detailText of situationData.details">
+                      {{ detailText }}
+                    </li>
+                  </ul>
+                </sbb-tooltip>
               </div>
-            </sbb-tooltip>
+            </div>
           </div>
         </div>
       </div>

--- a/src/app/station-board/result/station-board-result.component.html
+++ b/src/app/station-board/result/station-board-result.component.html
@@ -44,9 +44,11 @@
                 <p>
                   <strong>{{ situation.situationContent.summary }}</strong>
                 </p>
-                <div>
-                  {{ situation.situationContent.description }}
-                </div>
+                <ul class="tooltip-list">
+                  <li *ngFor="let descriptionText of situation.situationContent.descriptions">
+                    {{ descriptionText }}
+                  </li>
+                </ul>
                 <ul class="tooltip-list">
                   <li *ngFor="let detailText of situation.situationContent.details">
                     {{ detailText }}

--- a/src/app/station-board/result/station-board-result.component.html
+++ b/src/app/station-board/result/station-board-result.component.html
@@ -40,14 +40,31 @@
           </div>
           <div *ngIf="hasSituations(stopEntry)">
             <div class="d-flex gap-2">
-              <div *ngFor="let situationData of stopEntry.stopSituations">
+              <div *ngFor="let situationData of stopEntry.situations">
                 <sbb-tooltip svgIcon="fpl:info">
                   <p>
                     <strong>{{ situationData.summary }}</strong>
                   </p>
-                  <div>
-                    {{ situationData.description }}
-                  </div>
+
+                  <!-- Handle situations with one-description -->
+                  <ng-container *ngIf="situationData.descriptions.length === 1">
+                    <div>
+                      {{ situationData.descriptions[0] }}
+                    </div>
+                  </ng-container>
+
+                  <!-- Handle situations with 2 or more descriptions -->
+                  <ng-container *ngIf="situationData.descriptions.length > 1">
+                    <ul class="tooltip-list">
+                      <li *ngFor="let descriptionText of situationData.descriptions">
+                        {{ descriptionText }}
+                      </li>
+                    </ul>
+                  
+                    <!-- => insert a delimiter between description and detail -->
+                    <h6>Detail</h6>
+                  </ng-container>
+
                   <ul class="tooltip-list">
                     <li *ngFor="let detailText of situationData.details">
                       {{ detailText }}

--- a/src/app/station-board/result/station-board-result.component.scss
+++ b/src/app/station-board/result/station-board-result.component.scss
@@ -51,3 +51,8 @@
 .item-selected {
     background-color: #F5F5F5;
 }
+
+.tooltip-list {
+    margin-top: 16px;
+    margin-bottom: 8px;
+}

--- a/src/app/station-board/result/station-board-result.component.ts
+++ b/src/app/station-board/result/station-board-result.component.ts
@@ -3,6 +3,34 @@ import { AfterViewInit, Component, ElementRef, OnInit, ViewChild } from '@angula
 import * as OJP from 'ojp-sdk'
 
 import { StationBoardService } from '../station-board.service';
+import { SituationData } from '../../shared/types/situation-type';
+import { OJPHelpers } from '../../helpers/ojp-helpers';
+
+interface StationBoardTime {
+  stopTime: string
+  stopTimeActual: string | null
+  stopDelayText: string | null
+  
+  hasDelay: boolean
+  hasDelayDifferentTime: boolean
+}
+
+interface StationBoardModel {
+  stopEvent: OJP.StopEvent
+
+  serviceLineNumber: string
+  servicePtMode: string
+  tripNumber: string | null
+  tripHeading: string
+  tripOperator: string
+
+  mapStationBoardTime: Record<OJP.StationBoardType, StationBoardTime>
+  
+  stopPlatform: string | null
+  stopPlatformActual: string | null
+
+  situations: SituationData[]
+}
 
 @Component({
   selector: 'station-board-result',
@@ -11,7 +39,7 @@ import { StationBoardService } from '../station-board.service';
 })
 export class StationBoardResultComponent implements OnInit, AfterViewInit {
   @ViewChild('stationBoardWrapper') stationBoardWrapperRef: ElementRef | undefined;
-  public stopEventsData: OJP.StationBoardModel[]
+  public stopEventsData: StationBoardModel[]
   public selectedIDx: number | null
   public stationBoardType: OJP.StationBoardType
 
@@ -28,7 +56,7 @@ export class StationBoardResultComponent implements OnInit, AfterViewInit {
       const stopEvents = stationBoardData.items;
       this.stopEventsData = [];
       stopEvents.forEach(stopEvent => {
-        const stationBoardModel = stopEvent.asStationBoard();
+        const stationBoardModel = this.computeStationBoardModel(stopEvent);
         this.stopEventsData.push(stationBoardModel);
       })
 
@@ -65,7 +93,7 @@ export class StationBoardResultComponent implements OnInit, AfterViewInit {
     this.stationBoardService.stationBoardEntrySelected.emit(stationBoardEntry.stopEvent);
   }
 
-  public hasDelay(stopEvent: OJP.StationBoardModel): boolean {
+  public hasDelay(stopEvent: StationBoardModel): boolean {
     const stationBoardTime = stopEvent.mapStationBoardTime[this.stationBoardType];
     if (!stationBoardTime) {
       return false;
@@ -74,7 +102,7 @@ export class StationBoardResultComponent implements OnInit, AfterViewInit {
     return stationBoardTime.hasDelay;
   }
 
-  public hasDelayDifferentTime(stopEvent: OJP.StationBoardModel): boolean {
+  public hasDelayDifferentTime(stopEvent: StationBoardModel): boolean {
     const stationBoardTime = stopEvent.mapStationBoardTime[this.stationBoardType];
     if (!stationBoardTime) {
       return false;
@@ -83,7 +111,7 @@ export class StationBoardResultComponent implements OnInit, AfterViewInit {
     return stationBoardTime.hasDelayDifferentTime;
   }
 
-  public formatStopEventTime(stopEvent: OJP.StationBoardModel, key: 'stopTime' | 'stopTimeActual' | 'stopDelayText'): string | null {
+  public formatStopEventTime(stopEvent: StationBoardModel, key: 'stopTime' | 'stopTimeActual' | 'stopDelayText'): string | null {
     const stationBoardTime = stopEvent.mapStationBoardTime[this.stationBoardType];
     if (stationBoardTime === null) {
       return null;
@@ -93,7 +121,110 @@ export class StationBoardResultComponent implements OnInit, AfterViewInit {
     return timeF;
   }
 
-  public hasSituations(stopEvent: OJP.StationBoardModel): boolean {
-    return stopEvent.stopSituations.length > 0;
+  public hasSituations(stopEvent: StationBoardModel): boolean {
+    return stopEvent.situations.length > 0;
+  }
+
+  private computeServiceLineNumber(stopEvent: OJP.StopEvent): string {
+    const serviceShortName = stopEvent.journeyService.ptMode.shortName ?? 'N/A';
+    const serviceLineNumber = stopEvent.journeyService.serviceLineNumber;
+    if (serviceLineNumber) {
+        return serviceLineNumber
+    } else {
+        return serviceShortName;
+    }
+  }
+
+  private computeStopTime(stopTime: Date | null): string | null {
+    if (stopTime === null) {
+      return null
+    }
+
+    const stopTimeText = OJP.DateHelpers.formatTimeHHMM(stopTime);
+    
+    return stopTimeText;
+  }
+
+  private computeDelayTime(stopPoint: OJP.StopPoint, forBoardType: OJP.StationBoardType): string | null {
+    const isArrival = forBoardType === 'Arrivals';
+    const stopPointTime = isArrival ? stopPoint.arrivalData : stopPoint.departureData;
+
+    const delayMinutes = stopPointTime?.delayMinutes ?? null;
+    if (delayMinutes === null) {
+        return null;
+    }
+
+    if (delayMinutes === 0) {
+        return 'ON TIME';
+    }
+
+    const delayTextParts: string[] = []
+    delayTextParts.push(' ')
+    delayTextParts.push(delayMinutes > 0 ? '+' : '')
+    delayTextParts.push('' + delayMinutes)
+    delayTextParts.push("'");
+
+    const delayText = delayTextParts.join('');
+    return delayText;
+  }
+
+  private computeStopTimeData(stopPoint: OJP.StopPoint, forBoardType: OJP.StationBoardType): StationBoardTime | null {
+    const isArrival = forBoardType === 'Arrivals';
+    const stopPointTime = isArrival ? stopPoint.arrivalData : stopPoint.departureData;
+
+    if (stopPointTime === null) {
+        return null
+    }
+
+    const hasDelay = stopPointTime.delayMinutes !== null;
+    
+    const timetableTimeF = OJP.DateHelpers.formatTimeHHMM(stopPointTime.timetableTime);
+    const estimatedTimeF = stopPointTime.estimatedTime ? OJP.DateHelpers.formatTimeHHMM(stopPointTime.estimatedTime) : 'n/a';
+    const hasDelayDifferentTime = stopPointTime.estimatedTime ? (timetableTimeF !== estimatedTimeF) : false;
+
+    const stopTime = this.computeStopTime(stopPointTime.timetableTime);
+    if (stopTime === null) {
+        return null;
+    }
+
+    const stopTimeData: StationBoardTime = {
+        stopTime: stopTime,
+        stopTimeActual: this.computeStopTime(stopPointTime.estimatedTime ?? null),
+        stopDelayText: this.computeDelayTime(stopPoint, forBoardType),
+
+        hasDelay: hasDelay,
+        hasDelayDifferentTime: hasDelayDifferentTime,
+    }
+
+    return stopTimeData;
+  }
+
+  private computeStationBoardModel(stopEvent: OJP.StopEvent): StationBoardModel {
+    const serviceLineNumber = this.computeServiceLineNumber(stopEvent);
+    const servicePtMode = stopEvent.journeyService.ptMode.shortName ?? 'N/A';
+
+    const arrivalTime = this.computeStopTimeData(stopEvent.stopPoint, 'Arrivals');
+    const departureTime = this.computeStopTimeData(stopEvent.stopPoint, 'Departures');
+
+    const stopPlatformActual = stopEvent.stopPoint.plannedPlatform === stopEvent.stopPoint.actualPlatform ? null : stopEvent.stopPoint.actualPlatform;
+
+    const model = <StationBoardModel>{
+        stopEvent: stopEvent,
+        serviceLineNumber: serviceLineNumber,
+        servicePtMode: servicePtMode,
+        tripNumber: stopEvent.journeyService.journeyNumber, 
+        tripHeading: stopEvent.journeyService.destinationStopPlace?.stopPlaceName ?? 'N/A', 
+        tripOperator: stopEvent.journeyService.agencyID,
+        mapStationBoardTime: {
+            Arrivals: arrivalTime,
+            Departures: departureTime
+        },
+        stopPlatform: stopEvent.stopPoint.plannedPlatform, 
+        stopPlatformActual: stopPlatformActual,
+        
+        situations: OJPHelpers.computeSituationsData(stopEvent.stopPoint.siriSituations),
+    }
+
+    return model;
   }
 }


### PR DESCRIPTION
- use `0.10.1` version of [ojp-js](https://github.com/openTdataCH/ojp-js) SDK
- allow to display SIRI-SX situations with multiple descriptions
- adds support for trips with `Cancelled`, `Infeasable` Trip status
- adds support for `NotServicedStopa property for TimedLeg stops
- move the logic for `StationBoardModel` from the SDK into the GUI