### PR TITLE
Unify OJP versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ OJP-Demo URL: https://opentdatach.github.io/ojp-demo-app/
 
 ----
 
+6.June 2025
+- TripInfoRequest - use new SDK - [PR #245](https://github.com/openTdataCH/ojp-demo-app-src/pull/245)
+  - adds logic to compute `OJP_VERSION`: `1.0` or `2.0`, based on user params, path and host. Default is `2.0`
+  - use [ojp-sdk-legacy](https://www.npmjs.com/package/ojp-sdk-legacy) for OJP SDK and propagate the `OJP_VERSION`, `REQUESTOR_REF` when using it
+
 4.June 2025
 - TripInfoRequest - use new SDK - [PR #243](https://github.com/openTdataCH/ojp-demo-app-src/pull/243)
   - use `ojp-sdk-next` for TripInfoRequest

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Code / Demo App Implementation
 
 | Code Place | LIR | SER | TR | TIR | FR | TRR | Comments |
 | - | - | - | - | - | - | - | - |
-| `ojp-sdk-legacy` (legacy SDK) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | - | - | TRR is only available for OJP v2.0 |
+| `ojp-sdk-legacy` (legacy SDK) | :white_check_mark: | :white_check_mark: | :white_check_mark: | - | - | - | TRR is only available for OJP v2.0 |
 | `ojp-sdk-next` (new SDK) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |  |
 | DemoApp Beta | `legacy` | `legacy` | `legacy` | `ojp-sdk-next` | `ojp-sdk-next` | `ojp-sdk-next` | `legacy` is the old SDK (OJP v1 and v2, see above) |
 

--- a/README.md
+++ b/README.md
@@ -14,18 +14,17 @@ This is the source-code repository used for developing and deploying [OJP Demo](
 
 Javascript SDK branches
 
-| OJP | Branch | NPM | Demo App | Description |
-|-|-|-|-|-|
-| v1.0 | [ojp-js#ojp-v1](https://github.com/openTdataCH/ojp-js/tree/feature/ojp-v1) | [ojp-sdk-v1](https://www.npmjs.com/package/ojp-sdk-v1) | <ul><li>[PROD](https://opentdatach.github.io/ojp-demo-app/search)</li><li>[BETA v1](https://tools.odpch.ch/beta-ojp-demo/search)</ul> | original SDK, receives bug fixes or critical features needed for OJP 1.0  |
-| v2.0 | [ojp-js#ojp-v2](https://github.com/openTdataCH/ojp-js/tree/feature/ojp-v2) | Github branch | [BETA v2](https://tools.odpch.ch/ojp-demo-v2/search) | original SDK, receives all features until `ojp-sdk-next` branch is merged to main |
-| v2.0 | [ojp-js#ojp-sdk-next](https://github.com/openTdataCH/ojp-js/tree/feature/ojp-sdk-next) | [ojp-sdk-next](https://www.npmjs.com/package/ojp-sdk-next) - temporarely, long-term will be published under `ojp-sdk` | under development | new SDK code with models derived from XSD schema, this will be the main development reference for OJP JS SDK |
+| Branch | NPM | Demo App | Description |
+|-|-|-|-|
+| [ojp-js#ojp-sdk-legacy](https://github.com/openTdataCH/ojp-js/tree/feature/ojp-sdk-legacy) | [ojp-sdk-legacy](https://www.npmjs.com/package/ojp-sdk-legacy) | <ul><li>[PROD](https://opentdatach.github.io/ojp-demo-app/search)</li><li>[BETA v1](https://tools.odpch.ch/beta-ojp-demo/search)</li><li>[BETA v2](https://tools.odpch.ch/ojp-demo-v2/search)</li></ul> | original SDK, contains dual code for OJP `1.0`,`2.0` |
+| [ojp-js#ojp-sdk-next](https://github.com/openTdataCH/ojp-js/tree/feature/ojp-sdk-next) | [ojp-sdk-next](https://www.npmjs.com/package/ojp-sdk-next) - temporarely, long-term will be published under `ojp-sdk` | under development | new SDK code with models derived from XSD schema, this will be the main development reference for OJP JS SDK |
 
 Code / Demo App Implementation
 
 | Code Place | LIR | SER | TR | TIR | FR | TRR | Comments |
 | - | - | - | - | - | - | - | - |
-| ojp-js (legacy SDK) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | - | - | TRR is only available for OJP v2.0 |
-| ojp-sdk-next (new SDK) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |  |
+| `ojp-sdk-legacy` (legacy SDK) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | - | - | TRR is only available for OJP v2.0 |
+| `ojp-sdk-next` (new SDK) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |  |
 | DemoApp Beta | `legacy` | `legacy` | `legacy` | `ojp-sdk-next` | `ojp-sdk-next` | `ojp-sdk-next` | `legacy` is the old SDK (OJP v1 and v2, see above) |
 
 - LIR - LocationInformationRequest

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,9 +25,9 @@
         "cross-fetch": "3.1.5",
         "fast-xml-parser": "5.0.8",
         "mapbox-gl": "3.8.0",
+        "ojp-sdk-legacy": "0.18.7",
         "ojp-sdk-next": "0.20.17",
-        "ojp-sdk-v1": "0.18.6",
-        "ojp-shared-types": "0.0.6",
+        "ojp-shared-types": "0.0.7",
         "rxjs": "~7.5.0",
         "sax": "1.3.0",
         "stream": "0.0.2",
@@ -1270,13 +1270,13 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.27.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.4.tgz",
-      "integrity": "sha512-Y+bO6U+I7ZKaM5G5rDUZiYfUvQPUibYmAFe7EnKdnKBbVXDZxvp+MWOH5gYciY0EPk4EScsuFMQBbEfpdRKSCQ==",
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.6.tgz",
+      "integrity": "sha512-muE8Tt8M22638HU31A3CgfSUciwz1fhATfoVai05aPXGor//CdWDCbnlY1yvBPo07njuVOCNGCSp/GTt12lIug==",
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.27.2",
-        "@babel/types": "^7.27.3"
+        "@babel/types": "^7.27.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2660,9 +2660,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.3.tgz",
-      "integrity": "sha512-Y1GkI4ktrtvmawoSq+4FCVHNryea6uR+qUQy0AGxLSsjCX0nVmkYQMBLHDkXZuo5hGx7eYdnIaslsdBFm7zbUw==",
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.6.tgz",
+      "integrity": "sha512-ETyHEk2VHHvl9b9jZP5IHPavHYk57EhanlRRuae9XCpb/j5bDCbPPMOBfCWhnl/7EDJz0jEMCi/RhccCE8r1+Q==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -5044,9 +5044,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001720",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001720.tgz",
-      "integrity": "sha512-Ec/2yV2nNPwb4DnTANEV99ZWwm3ZWfdlfkQbWSDDt+PsXEVYwlhPH8tdMaPunYTKKmz7AnHi2oNEi1GcmKCD8g==",
+      "version": "1.0.30001721",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001721.tgz",
+      "integrity": "sha512-cOuvmUVtKrtEaoKiO0rSc29jcjwMwX5tOHDy4MgVFEWiUXj4uBMJkwI8MDySkgXidpMiHUcviogAvFi4pA2hDQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -6054,9 +6054,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.162",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.162.tgz",
-      "integrity": "sha512-hQA+Zb5QQwoSaXJWEAGEw1zhk//O7qDzib05Z4qTqZfNju/FAkrm5ZInp0JbTp4Z18A6bilopdZWEYrFSsfllA==",
+      "version": "1.5.165",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.165.tgz",
+      "integrity": "sha512-naiMx1Z6Nb2TxPU6fiFrUrDTjyPMLdTtaOd2oLmG8zVSg2hCWGkhPyxwk+qRmZ1ytwVqUv0u7ZcDA5+ALhaUtw==",
       "license": "ISC"
     },
     "node_modules/email-addresses": {
@@ -7204,14 +7204,15 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
+      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {
@@ -10354,21 +10355,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/ojp-sdk-next": {
-      "version": "0.20.17",
-      "resolved": "https://registry.npmjs.org/ojp-sdk-next/-/ojp-sdk-next-0.20.17.tgz",
-      "integrity": "sha512-GRKBKlCxABixEUEFq/lZEX67m1B4M/pvGXbVPGy/pQxB5NpWcQje466phKs86nNUSjrMPG5Yi3N/Eh5I9auQ1g==",
-      "license": "MIT",
-      "dependencies": {
-        "axios": "1.8.3",
-        "fast-xml-parser": "5.0.8",
-        "ojp-shared-types": "0.0.6"
-      }
-    },
-    "node_modules/ojp-sdk-v1": {
-      "version": "0.18.6",
-      "resolved": "https://registry.npmjs.org/ojp-sdk-v1/-/ojp-sdk-v1-0.18.6.tgz",
-      "integrity": "sha512-iNK8LiXqKS8//IMuiOPPsummSk1lOua3/5andvRj6Da/0tv8kCgmt8r9yHfoqfgiDj+STIhIJdiRTv19YI7SRw==",
+    "node_modules/ojp-sdk-legacy": {
+      "version": "0.18.7",
+      "resolved": "https://registry.npmjs.org/ojp-sdk-legacy/-/ojp-sdk-legacy-0.18.7.tgz",
+      "integrity": "sha512-QSNtF8a0PzgYShvq+8C3DmXFSHZIyK4aGDnCGfkSSM6dRixRYC0dN6A3lm03Q0xF9iukdHnVVC0wrpvY18uLRw==",
       "license": "MIT",
       "dependencies": {
         "@xmldom/xmldom": "0.8.7",
@@ -10383,10 +10373,105 @@
         "sax-ts": "1.2.13"
       }
     },
-    "node_modules/ojp-shared-types": {
+    "node_modules/ojp-sdk-next": {
+      "version": "0.20.17",
+      "resolved": "https://registry.npmjs.org/ojp-sdk-next/-/ojp-sdk-next-0.20.17.tgz",
+      "integrity": "sha512-GRKBKlCxABixEUEFq/lZEX67m1B4M/pvGXbVPGy/pQxB5NpWcQje466phKs86nNUSjrMPG5Yi3N/Eh5I9auQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "1.8.3",
+        "fast-xml-parser": "5.0.8",
+        "ojp-shared-types": "0.0.6"
+      }
+    },
+    "node_modules/ojp-sdk-next/node_modules/ojp-shared-types": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/ojp-shared-types/-/ojp-shared-types-0.0.6.tgz",
       "integrity": "sha512-ObJpQ3/asvn3kkgYpEKh+mabdlejAhRVRuDdMmynaLaUQF485gGGyJkGvr+FXxZgQqwl9Oe/KMpjrtxTBSg8kw==",
+      "license": "MIT",
+      "dependencies": {
+        "openapi-typescript": "7.8.0"
+      }
+    },
+    "node_modules/ojp-sdk-next/node_modules/openapi-typescript": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-7.8.0.tgz",
+      "integrity": "sha512-1EeVWmDzi16A+siQlo/SwSGIT7HwaFAVjvMA7/jG5HMLSnrUOzPL7uSTRZZa4v/LCRxHTApHKtNY6glApEoiUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@redocly/openapi-core": "^1.34.3",
+        "ansi-colors": "^4.1.3",
+        "change-case": "^5.4.4",
+        "parse-json": "^8.3.0",
+        "supports-color": "^10.0.0",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "openapi-typescript": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "typescript": "^5.x"
+      }
+    },
+    "node_modules/ojp-sdk-next/node_modules/parse-json": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+      "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.26.2",
+        "index-to-position": "^1.1.0",
+        "type-fest": "^4.39.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ojp-sdk-next/node_modules/supports-color": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.0.0.tgz",
+      "integrity": "sha512-HRVVSbCCMbj7/kdWF9Q+bbckjBHLtHMEoJWlkmYzzdwhYMkjkOwubLM6t7NbWKjgKamGDrWL1++KrjUO1t9oAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/ojp-sdk-next/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ojp-sdk-next/node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ojp-shared-types": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/ojp-shared-types/-/ojp-shared-types-0.0.7.tgz",
+      "integrity": "sha512-sYd8Vy8vWTq1YEN2er+9e/dpe7ydnEPxhfl7jYhnXaP2v0pfXj/zWW/ccn+eKcVElGOLj2TSXNXeD5VpNoeDCQ==",
       "license": "MIT",
       "dependencies": {
         "openapi-typescript": "7.8.0"
@@ -13662,9 +13747,9 @@
       }
     },
     "node_modules/terser-webpack-plugin/node_modules/terser": {
-      "version": "5.40.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.40.0.tgz",
-      "integrity": "sha512-cfeKl/jjwSR5ar7d0FGmave9hFGJT8obyo0z+CrQOylLDbk7X81nPU6vq9VORa5jU30SkDnT2FXjLbR8HLP+xA==",
+      "version": "5.41.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.41.0.tgz",
+      "integrity": "sha512-H406eLPXpZbAX14+B8psIuvIr8+3c+2hkuYzpMkoE0ij+NdsVATbA78vb8neA/eqrj7rywa2pIkdmWRsXW6wmw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,8 +26,8 @@
         "fast-xml-parser": "5.0.8",
         "mapbox-gl": "3.8.0",
         "ojp-sdk-legacy": "0.18.7",
-        "ojp-sdk-next": "0.20.17",
-        "ojp-shared-types": "0.0.7",
+        "ojp-sdk-next": "0.20.18",
+        "ojp-shared-types": "0.0.8",
         "rxjs": "~7.5.0",
         "sax": "1.3.0",
         "stream": "0.0.2",
@@ -3846,9 +3846,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.15.29",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.29.tgz",
-      "integrity": "sha512-LNdjOkUDlU1RZb8e1kOIUpN1qQUlzGkEtbVNo53vbrwDg5om6oduhm4SiUaPW5ASTXhAiP0jInWG8Qx9fVlOeQ==",
+      "version": "22.15.30",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.30.tgz",
+      "integrity": "sha512-6Q7lr06bEHdlfplU6YRbgG1SFBdlsfNC4/lX+SkhiTs0cpJkOElmWls8PxDFv4yY/xKb8Y6SO0OmSX4wgqTZbA==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -10374,104 +10374,20 @@
       }
     },
     "node_modules/ojp-sdk-next": {
-      "version": "0.20.17",
-      "resolved": "https://registry.npmjs.org/ojp-sdk-next/-/ojp-sdk-next-0.20.17.tgz",
-      "integrity": "sha512-GRKBKlCxABixEUEFq/lZEX67m1B4M/pvGXbVPGy/pQxB5NpWcQje466phKs86nNUSjrMPG5Yi3N/Eh5I9auQ1g==",
+      "version": "0.20.18",
+      "resolved": "https://registry.npmjs.org/ojp-sdk-next/-/ojp-sdk-next-0.20.18.tgz",
+      "integrity": "sha512-tEpv5M7qE1O27fFQzxv07a3VJICuy45qFi1rxe7z5MYxLPn9Fl22M5ogaKE5TaoiuS/LGBmeu0GA5a0hRtb/aA==",
       "license": "MIT",
       "dependencies": {
         "axios": "1.8.3",
         "fast-xml-parser": "5.0.8",
-        "ojp-shared-types": "0.0.6"
-      }
-    },
-    "node_modules/ojp-sdk-next/node_modules/ojp-shared-types": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/ojp-shared-types/-/ojp-shared-types-0.0.6.tgz",
-      "integrity": "sha512-ObJpQ3/asvn3kkgYpEKh+mabdlejAhRVRuDdMmynaLaUQF485gGGyJkGvr+FXxZgQqwl9Oe/KMpjrtxTBSg8kw==",
-      "license": "MIT",
-      "dependencies": {
-        "openapi-typescript": "7.8.0"
-      }
-    },
-    "node_modules/ojp-sdk-next/node_modules/openapi-typescript": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-7.8.0.tgz",
-      "integrity": "sha512-1EeVWmDzi16A+siQlo/SwSGIT7HwaFAVjvMA7/jG5HMLSnrUOzPL7uSTRZZa4v/LCRxHTApHKtNY6glApEoiUQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@redocly/openapi-core": "^1.34.3",
-        "ansi-colors": "^4.1.3",
-        "change-case": "^5.4.4",
-        "parse-json": "^8.3.0",
-        "supports-color": "^10.0.0",
-        "yargs-parser": "^21.1.1"
-      },
-      "bin": {
-        "openapi-typescript": "bin/cli.js"
-      },
-      "peerDependencies": {
-        "typescript": "^5.x"
-      }
-    },
-    "node_modules/ojp-sdk-next/node_modules/parse-json": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
-      "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.26.2",
-        "index-to-position": "^1.1.0",
-        "type-fest": "^4.39.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ojp-sdk-next/node_modules/supports-color": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.0.0.tgz",
-      "integrity": "sha512-HRVVSbCCMbj7/kdWF9Q+bbckjBHLtHMEoJWlkmYzzdwhYMkjkOwubLM6t7NbWKjgKamGDrWL1++KrjUO1t9oAQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/ojp-sdk-next/node_modules/type-fest": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ojp-sdk-next/node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
+        "ojp-shared-types": "0.0.8"
       }
     },
     "node_modules/ojp-shared-types": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/ojp-shared-types/-/ojp-shared-types-0.0.7.tgz",
-      "integrity": "sha512-sYd8Vy8vWTq1YEN2er+9e/dpe7ydnEPxhfl7jYhnXaP2v0pfXj/zWW/ccn+eKcVElGOLj2TSXNXeD5VpNoeDCQ==",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/ojp-shared-types/-/ojp-shared-types-0.0.8.tgz",
+      "integrity": "sha512-3lttuxXcAz4iTO6/K8hELnB5m4t7B0ETCzhdE3Khs8QAID+Fo3Mu6IP1S7ehVl4Y6kJ6Ppv1vQ+3rjOMthzjWg==",
       "license": "MIT",
       "dependencies": {
         "openapi-typescript": "7.8.0"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "tslib": "^2.3.0",
     "zone.js": "~0.11.4",
 
-    "ojp-sdk-v1": "0.18.6",
+    "ojp-sdk-legacy": "0.18.7",
     "ojp-shared-types": "0.0.7",
     "ojp-sdk-next": "0.20.17",
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "zone.js": "~0.11.4",
 
     "ojp-sdk-v1": "0.18.6",
-    "ojp-shared-types": "0.0.6",
+    "ojp-shared-types": "0.0.7",
     "ojp-sdk-next": "0.20.17",
 
     "cross-fetch": "3.1.5",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "zone.js": "~0.11.4",
 
     "ojp-sdk-legacy": "0.18.7",
-    "ojp-shared-types": "0.0.7",
-    "ojp-sdk-next": "0.20.17",
+    "ojp-shared-types": "0.0.8",
+    "ojp-sdk-next": "0.20.18",
 
     "cross-fetch": "3.1.5",
     "sax": "1.3.0",

--- a/src/app/config/app-config.ts
+++ b/src/app/config/app-config.ts
@@ -1,4 +1,7 @@
-import { AppConfig } from '../shared/types/app-config'
+import { AppConfig } from '../shared/types/app-config';
+import OJP_Legacy from './ojp-legacy';
+
+export const OJP_VERSION: OJP_Legacy.OJP_VERSION_Type = '2.0';
 
 export const APP_CONFIG: AppConfig = {
   stages: {

--- a/src/app/config/app-config.ts
+++ b/src/app/config/app-config.ts
@@ -1,7 +1,4 @@
 import { AppConfig } from '../shared/types/app-config';
-import OJP_Legacy from './ojp-legacy';
-
-export const OJP_VERSION: OJP_Legacy.OJP_VERSION_Type = '2.0';
 
 export const APP_CONFIG: AppConfig = {
   stages: {

--- a/src/app/config/constants.ts
+++ b/src/app/config/constants.ts
@@ -1,3 +1,4 @@
+import { OJP_VERSION } from './app-config';
 import OJP_Legacy from './ojp-legacy';
 
 type DEBUG_LEVEL_Type = 'DEBUG' | 'PROD'
@@ -13,8 +14,6 @@ export const DEBUG_LEVEL: DEBUG_LEVEL_Type = (() => {
 
   return 'DEBUG';
 })();
-
-export const OJP_VERSION: OJP_Legacy.OJP_VERSION_Type = '2.0';
 
 export type APP_STAGE = 'PROD' | 'INT' | 'TEST' | 'LA Beta' 
   | 'V2-PROD' | 'V2-INT' | 'V2-TEST'

--- a/src/app/config/constants.ts
+++ b/src/app/config/constants.ts
@@ -14,12 +14,13 @@ export const DEBUG_LEVEL: DEBUG_LEVEL_Type = (() => {
   return 'DEBUG';
 })();
 
+export const OJP_VERSION: OJP_Legacy.OJP_VERSION_Type = '2.0';
+
 export type APP_STAGE = 'PROD' | 'INT' | 'TEST' | 'LA Beta' 
   | 'V2-PROD' | 'V2-INT' | 'V2-TEST'
   | 'GR TEST'| 'PROD-LB' | 'OJP-SI' | 'NOVA-INT';
 
-const isOJPv2 = OJP_Legacy.OJP_VERSION === '2.0';
-
+const isOJPv2 = ((OJP_VERSION as any) as OJP_Legacy.OJP_VERSION_Type) === '2.0';
 export const DEFAULT_APP_STAGE: APP_STAGE = isOJPv2 ? 'V2-PROD' : 'PROD';
 
 export const APP_STAGEs: APP_STAGE[] = (() => {
@@ -37,7 +38,7 @@ export const APP_STAGEs: APP_STAGE[] = (() => {
   return stages;
 })();
 
-export const REQUESTOR_REF = 'OJP_DemoApp_Beta_OJP' + OJP_Legacy.OJP_VERSION;
+export const REQUESTOR_REF = 'OJP_DemoApp_Beta_OJP' + OJP_VERSION;
 
 export interface AppMapLayerOptions {
   LIR_Restriction_Type: OJP_Legacy.RestrictionType

--- a/src/app/config/constants.ts
+++ b/src/app/config/constants.ts
@@ -1,4 +1,3 @@
-import { OJP_VERSION } from './app-config';
 import OJP_Legacy from './ojp-legacy';
 
 type DEBUG_LEVEL_Type = 'DEBUG' | 'PROD'
@@ -13,6 +12,10 @@ export const DEBUG_LEVEL: DEBUG_LEVEL_Type = (() => {
   }
 
   return 'DEBUG';
+})();
+
+export const OJP_VERSION: OJP_Legacy.OJP_VERSION_Type = (() => {
+  return '2.0' as OJP_Legacy.OJP_VERSION_Type;
 })();
 
 export type APP_STAGE = 'PROD' | 'INT' | 'TEST' | 'LA Beta' 

--- a/src/app/config/constants.ts
+++ b/src/app/config/constants.ts
@@ -15,6 +15,28 @@ export const DEBUG_LEVEL: DEBUG_LEVEL_Type = (() => {
 })();
 
 export const OJP_VERSION: OJP_Legacy.OJP_VERSION_Type = (() => {
+  const queryParams = new URLSearchParams(document.location.search);
+  const userVersion = queryParams.get('v');
+  if (userVersion === '1') {
+    return '1.0';
+  }
+  if (userVersion === '2') {
+    return '2.0';
+  }
+
+  const host = document.location.hostname;
+  if (host === 'opentdatach.github.io') {
+    return '1.0';
+  }
+
+  const path = document.location.pathname;
+  if (path.startsWith('/ojp-demo-v2')) {
+    return '2.0';
+  }
+  if (path.startsWith('/beta-ojp-demo')) {
+    return '1.0';
+  }
+
   return '2.0' as OJP_Legacy.OJP_VERSION_Type;
 })();
 

--- a/src/app/config/ojp-legacy.ts
+++ b/src/app/config/ojp-legacy.ts
@@ -1,2 +1,2 @@
-import * as OJP_Legacy from 'ojp-sdk-v1';
+import * as OJP_Legacy from 'ojp-sdk-legacy';
 export default OJP_Legacy;

--- a/src/app/journey/journey-result-row/journey-result-row.component.ts
+++ b/src/app/journey/journey-result-row/journey-result-row.component.ts
@@ -4,7 +4,9 @@ import { SbbExpansionPanel } from '@sbb-esta/angular/accordion';
 import OJP_Legacy from '../../config/ojp-legacy';
 import * as OJP_Next from 'ojp-sdk-next';
 
-import { DEBUG_LEVEL, OJP_VERSION, REQUESTOR_REF } from '../../config/constants';
+import { DEBUG_LEVEL, REQUESTOR_REF } from '../../config/constants';
+import { OJP_VERSION } from '../../config/app-config';
+
 import { UserTripService } from '../../shared/services/user-trip.service';
 import { MapService } from '../../shared/services/map.service';
 import { LanguageService } from '../../shared/services/language.service';

--- a/src/app/journey/journey-result-row/journey-result-row.component.ts
+++ b/src/app/journey/journey-result-row/journey-result-row.component.ts
@@ -4,8 +4,7 @@ import { SbbExpansionPanel } from '@sbb-esta/angular/accordion';
 import OJP_Legacy from '../../config/ojp-legacy';
 import * as OJP_Next from 'ojp-sdk-next';
 
-import { DEBUG_LEVEL, REQUESTOR_REF } from '../../config/constants';
-import { OJP_VERSION } from '../../config/app-config';
+import { DEBUG_LEVEL, REQUESTOR_REF, OJP_VERSION } from '../../config/constants';
 
 import { UserTripService } from '../../shared/services/user-trip.service';
 import { MapService } from '../../shared/services/map.service';

--- a/src/app/journey/journey-result-row/journey-result-row.component.ts
+++ b/src/app/journey/journey-result-row/journey-result-row.component.ts
@@ -4,7 +4,7 @@ import { SbbExpansionPanel } from '@sbb-esta/angular/accordion';
 import OJP_Legacy from '../../config/ojp-legacy';
 import * as OJP_Next from 'ojp-sdk-next';
 
-import { DEBUG_LEVEL, REQUESTOR_REF } from '../../config/constants';
+import { DEBUG_LEVEL, OJP_VERSION, REQUESTOR_REF } from '../../config/constants';
 import { UserTripService } from '../../shared/services/user-trip.service';
 import { MapService } from '../../shared/services/map.service';
 import { LanguageService } from '../../shared/services/language.service';
@@ -149,7 +149,10 @@ export class JourneyResultRowComponent implements OnInit {
       return;
     }
 
-    const tripXML = this.tripData.trip.asXML();
+    const isOJPv2 = OJP_VERSION === '2.0';
+    const xmlConfig = isOJPv2 ? OJP_Legacy.XML_ConfigOJPv2 : OJP_Legacy.XML_BuilderConfigOJPv1;
+
+    const tripXML = this.tripData.trip.asXML(xmlConfig);
     // console.log(tripXML);
 
     // TODO - when migrating this code to next version we dont need to serialize/deserialize the obj anymore
@@ -175,7 +178,8 @@ export class JourneyResultRowComponent implements OnInit {
     this.trrRequestInfo = trrRequest.requestInfo;
 
     // TRR response is similar with TR response
-    const trRequest = OJP_Legacy.TripRequest.initWithResponseMock(trrRequest.requestInfo.responseXML);
+    const trRequest = OJP_Legacy.TripRequest.initWithResponseMock(trrRequest.requestInfo.responseXML, xmlConfig, REQUESTOR_REF);
+    
     const trResponse = await trRequest.fetchResponse();
 
     if (trResponse.trips.length !== 1) {

--- a/src/app/journey/journey-result-row/journey-result-row.component.ts
+++ b/src/app/journey/journey-result-row/journey-result-row.component.ts
@@ -166,7 +166,14 @@ export class JourneyResultRowComponent implements OnInit {
     const stage = this.userTripService.getStageConfig();
 
     const ojpSDK_Next = new OJP_Next.SDK(REQUESTOR_REF, stage, this.languageService.language);
-    await ojpSDK_Next.fetchTRR_Trips(trrRequest);
+    const trrResponse = await ojpSDK_Next.fetchTripRefineRequestResponse(trrRequest);
+    if (!trrResponse.ok) {
+      console.error('ERROR - fetchTripRefineRequestResponse');
+      console.log(trrRequest);
+      console.log(trrResponse);
+      debugger;
+      return;
+    }
 
     if (trrRequest.requestInfo.responseXML === null) {
       console.error('no responseXML');

--- a/src/app/journey/journey-result-row/result-trip-leg/result-trip-leg.component.ts
+++ b/src/app/journey/journey-result-row/result-trip-leg/result-trip-leg.component.ts
@@ -9,7 +9,9 @@ import { SbbDialog } from "@sbb-esta/angular/dialog";
 import OJP_Legacy from '../../../config/ojp-legacy';
 import * as OJP_Next from 'ojp-sdk-next';
 
-import { DEBUG_LEVEL, OJP_VERSION } from '../../../config/constants';
+import { OJP_VERSION } from '../../../config/app-config';
+import { DEBUG_LEVEL } from '../../../config/constants';
+
 import { MapLegLineTypeColor } from '../../../config/map-colors';
 import { OJPHelpers } from '../../../helpers/ojp-helpers';
 

--- a/src/app/journey/journey-result-row/result-trip-leg/result-trip-leg.component.ts
+++ b/src/app/journey/journey-result-row/result-trip-leg/result-trip-leg.component.ts
@@ -9,8 +9,7 @@ import { SbbDialog } from "@sbb-esta/angular/dialog";
 import OJP_Legacy from '../../../config/ojp-legacy';
 import * as OJP_Next from 'ojp-sdk-next';
 
-import { OJP_VERSION } from '../../../config/app-config';
-import { DEBUG_LEVEL } from '../../../config/constants';
+import { DEBUG_LEVEL, OJP_VERSION } from '../../../config/constants';
 
 import { MapLegLineTypeColor } from '../../../config/map-colors';
 import { OJPHelpers } from '../../../helpers/ojp-helpers';

--- a/src/app/journey/journey-result-row/result-trip-leg/result-trip-leg.component.ts
+++ b/src/app/journey/journey-result-row/result-trip-leg/result-trip-leg.component.ts
@@ -9,7 +9,7 @@ import { SbbDialog } from "@sbb-esta/angular/dialog";
 import OJP_Legacy from '../../../config/ojp-legacy';
 import * as OJP_Next from 'ojp-sdk-next';
 
-import { DEBUG_LEVEL } from '../../../config/constants';
+import { DEBUG_LEVEL, OJP_VERSION } from '../../../config/constants';
 import { MapLegLineTypeColor } from '../../../config/map-colors';
 import { OJPHelpers } from '../../../helpers/ojp-helpers';
 
@@ -94,8 +94,8 @@ export class ResultTripLegComponent implements OnInit {
   constructor(private mapService: MapService, private router: Router, private popover: SbbDialog, private userTripService: UserTripService, private sanitizer: DomSanitizer) {
     this.legInfoDataModel = <LegInfoDataModel>{}
     this.isEmbed = this.router.url.indexOf('/embed/') !== -1;
-    
-    const isOJPv2 = OJP_Legacy.OJP_VERSION === '2.0';
+
+    const isOJPv2 = OJP_VERSION === '2.0';
     this.enableTRR = isOJPv2;
   }
 

--- a/src/app/journey/journey-result-row/result-trip-leg/trip-info-result-popover/trip-info-result-popover.component.ts
+++ b/src/app/journey/journey-result-row/result-trip-leg/trip-info-result-popover/trip-info-result-popover.component.ts
@@ -3,10 +3,12 @@ import { Component } from '@angular/core';
 import OJP_Legacy from '../../../../config/ojp-legacy';
 import * as OJP_Next from 'ojp-sdk-next';
 
+import { REQUESTOR_REF } from '../../../../config/constants';
+import { OJP_VERSION } from '../../../../config/app-config';
+
 import { UserTripService } from '../../../../shared/services/user-trip.service';
 import { TripInfoService } from '../../../../trip-info/trip-info.service';
 import { LanguageService } from '../../../../shared/services/language.service'
-import { OJP_VERSION, REQUESTOR_REF } from '../../../../config/constants';
 import { TripInfoResult } from '../../../../shared/models/trip-info-result';
 
 interface PageModel {

--- a/src/app/journey/journey-result-row/result-trip-leg/trip-info-result-popover/trip-info-result-popover.component.ts
+++ b/src/app/journey/journey-result-row/result-trip-leg/trip-info-result-popover/trip-info-result-popover.component.ts
@@ -3,8 +3,7 @@ import { Component } from '@angular/core';
 import OJP_Legacy from '../../../../config/ojp-legacy';
 import * as OJP_Next from 'ojp-sdk-next';
 
-import { REQUESTOR_REF } from '../../../../config/constants';
-import { OJP_VERSION } from '../../../../config/app-config';
+import { REQUESTOR_REF, OJP_VERSION } from '../../../../config/constants';
 
 import { UserTripService } from '../../../../shared/services/user-trip.service';
 import { TripInfoService } from '../../../../trip-info/trip-info.service';

--- a/src/app/journey/journey-result-row/result-trip-leg/trip-info-result-popover/trip-info-result-popover.component.ts
+++ b/src/app/journey/journey-result-row/result-trip-leg/trip-info-result-popover/trip-info-result-popover.component.ts
@@ -6,7 +6,7 @@ import * as OJP_Next from 'ojp-sdk-next';
 import { UserTripService } from '../../../../shared/services/user-trip.service';
 import { TripInfoService } from '../../../../trip-info/trip-info.service';
 import { LanguageService } from '../../../../shared/services/language.service'
-import { REQUESTOR_REF } from '../../../../config/constants';
+import { OJP_VERSION, REQUESTOR_REF } from '../../../../config/constants';
 import { TripInfoResult } from '../../../../shared/models/trip-info-result';
 
 interface PageModel {
@@ -56,8 +56,11 @@ export class TripInfoResultPopoverComponent {
   }
 
   private createOJP_SDK_Instance(): OJP_Next.SDK {
-    const stageConfig = this.userTripService.getStageConfig();    
-    const sdk = new OJP_Next.SDK(REQUESTOR_REF, stageConfig, this.languageService.language, OJP_Legacy.XML_BuilderConfig);
+    const stageConfig = this.userTripService.getStageConfig();
+    const isOJPv2 = OJP_VERSION === '2.0';
+    const xmlConfig = isOJPv2 ? OJP_Legacy.XML_ConfigOJPv2 : OJP_Legacy.XML_BuilderConfigOJPv1;
+
+    const sdk = new OJP_Next.SDK(REQUESTOR_REF, stageConfig, this.languageService.language, xmlConfig);
     return sdk;
   }
 }

--- a/src/app/journey/journey-results/journey-results.component.ts
+++ b/src/app/journey/journey-results/journey-results.component.ts
@@ -2,10 +2,13 @@ import { Component, OnInit } from '@angular/core';
 import { UserTripService } from 'src/app/shared/services/user-trip.service';
 
 import OJP_Legacy from '../../config/ojp-legacy';
+
+import { REQUESTOR_REF } from '../../config/constants';
+import { OJP_VERSION } from '../../config/app-config';
+
 import { MapService } from '../../shared/services/map.service'
 import { LanguageService } from '../../shared/services/language.service';
 import { TripData } from '../../shared/types/trip';
-import { OJP_VERSION, REQUESTOR_REF } from '../../config/constants';
 
 type NumberOfResultsType = 'NumberOfResults' | 'NumberOfResultsBefore' | 'NumberOfResultsAfter';
 

--- a/src/app/journey/journey-results/journey-results.component.ts
+++ b/src/app/journey/journey-results/journey-results.component.ts
@@ -5,6 +5,7 @@ import OJP_Legacy from '../../config/ojp-legacy';
 import { MapService } from '../../shared/services/map.service'
 import { LanguageService } from '../../shared/services/language.service';
 import { TripData } from '../../shared/types/trip';
+import { OJP_VERSION, REQUESTOR_REF } from '../../config/constants';
 
 type NumberOfResultsType = 'NumberOfResults' | 'NumberOfResultsBefore' | 'NumberOfResultsAfter';
 
@@ -127,9 +128,15 @@ export class JourneyResultsComponent implements OnInit {
     }
 
     const stageConfig = this.userTripService.getStageConfig();
+    const isOJPv2 = OJP_VERSION === '2.0';
+    const xmlConfig = isOJPv2 ? OJP_Legacy.XML_ConfigOJPv2 : OJP_Legacy.XML_BuilderConfigOJPv1;
+    
     const request = OJP_Legacy.TripRequest.initWithTripLocationsAndDate(
       stageConfig,
       this.languageService.language,
+      xmlConfig,
+      REQUESTOR_REF,
+      
       this.userTripService.fromTripLocation,
       this.userTripService.toTripLocation,
       depArrDate,

--- a/src/app/journey/journey-results/journey-results.component.ts
+++ b/src/app/journey/journey-results/journey-results.component.ts
@@ -3,8 +3,7 @@ import { UserTripService } from 'src/app/shared/services/user-trip.service';
 
 import OJP_Legacy from '../../config/ojp-legacy';
 
-import { REQUESTOR_REF } from '../../config/constants';
-import { OJP_VERSION } from '../../config/app-config';
+import { REQUESTOR_REF, OJP_VERSION } from '../../config/constants';
 
 import { MapService } from '../../shared/services/map.service'
 import { LanguageService } from '../../shared/services/language.service';

--- a/src/app/map/app-map-layer/app-map-layer.ts
+++ b/src/app/map/app-map-layer/app-map-layer.ts
@@ -3,7 +3,7 @@ import mapboxgl from "mapbox-gl";
 
 import OJP_Legacy from '../../config/ojp-legacy';
 
-import { AppMapLayerOptions, DEBUG_LEVEL, MAP_APP_MAP_LAYERS } from '../../config/constants'
+import { AppMapLayerOptions, DEBUG_LEVEL, MAP_APP_MAP_LAYERS, OJP_VERSION, REQUESTOR_REF } from '../../config/constants'
 import { UserTripService } from "../../shared/services/user-trip.service";
 import { MapHelpers } from "../helpers/map.helpers";
 import { MAP_LAYERS_DEFINITIONS } from "./map-layers-def";
@@ -115,9 +115,15 @@ export class AppMapLayer {
             return;
         }
 
+        const isOJPv2 = OJP_VERSION === '2.0';
+        const xmlConfig = isOJPv2 ? OJP_Legacy.XML_ConfigOJPv2 : OJP_Legacy.XML_BuilderConfigOJPv1;
+
         const request = OJP_Legacy.LocationInformationRequest.initWithBBOXAndType(
             this.userTripService.getStageConfig(),
             this.language,
+            xmlConfig,
+            REQUESTOR_REF,
+
             mapBounds.getWest(),
             mapBounds.getNorth(),
             mapBounds.getEast(),

--- a/src/app/map/app-map-layer/app-map-layer.ts
+++ b/src/app/map/app-map-layer/app-map-layer.ts
@@ -3,8 +3,7 @@ import mapboxgl from "mapbox-gl";
 
 import OJP_Legacy from '../../config/ojp-legacy';
 
-import { AppMapLayerOptions, DEBUG_LEVEL, MAP_APP_MAP_LAYERS, REQUESTOR_REF } from '../../config/constants'
-import { OJP_VERSION } from '../../config/app-config';
+import { AppMapLayerOptions, DEBUG_LEVEL, MAP_APP_MAP_LAYERS, REQUESTOR_REF, OJP_VERSION } from '../../config/constants'
 
 import { UserTripService } from "../../shared/services/user-trip.service";
 import { MapHelpers } from "../helpers/map.helpers";

--- a/src/app/map/app-map-layer/app-map-layer.ts
+++ b/src/app/map/app-map-layer/app-map-layer.ts
@@ -3,7 +3,9 @@ import mapboxgl from "mapbox-gl";
 
 import OJP_Legacy from '../../config/ojp-legacy';
 
-import { AppMapLayerOptions, DEBUG_LEVEL, MAP_APP_MAP_LAYERS, OJP_VERSION, REQUESTOR_REF } from '../../config/constants'
+import { AppMapLayerOptions, DEBUG_LEVEL, MAP_APP_MAP_LAYERS, REQUESTOR_REF } from '../../config/constants'
+import { OJP_VERSION } from '../../config/app-config';
+
 import { UserTripService } from "../../shared/services/user-trip.service";
 import { MapHelpers } from "../helpers/map.helpers";
 import { MAP_LAYERS_DEFINITIONS } from "./map-layers-def";

--- a/src/app/search-form/input-xml-popover/input-xml-popover.component.ts
+++ b/src/app/search-form/input-xml-popover/input-xml-popover.component.ts
@@ -2,7 +2,9 @@ import { Component, EventEmitter, Output } from '@angular/core';
 import { UserTripService } from 'src/app/shared/services/user-trip.service';
 
 import OJP_Legacy from '../../config/ojp-legacy';
-import { OJP_VERSION, REQUESTOR_REF } from '../../config/constants';
+
+import { REQUESTOR_REF } from '../../config/constants';
+import { OJP_VERSION } from '../../config/app-config';
 
 @Component({
   selector: 'input-xml-popover',

--- a/src/app/search-form/input-xml-popover/input-xml-popover.component.ts
+++ b/src/app/search-form/input-xml-popover/input-xml-popover.component.ts
@@ -2,6 +2,7 @@ import { Component, EventEmitter, Output } from '@angular/core';
 import { UserTripService } from 'src/app/shared/services/user-trip.service';
 
 import OJP_Legacy from '../../config/ojp-legacy';
+import { OJP_VERSION, REQUESTOR_REF } from '../../config/constants';
 
 @Component({
   selector: 'input-xml-popover',
@@ -24,10 +25,12 @@ export class InputXmlPopoverComponent {
   }
 
   public parseCustomRequestXML() {
-    this.isRunningTripRequest = true
+    this.isRunningTripRequest = true;
 
-    const stageConfig = this.userTripService.getStageConfig();
-    const request = OJP_Legacy.TripRequest.initWithRequestMock(this.inputTripRequestXML, stageConfig);
+    const isOJPv2 = OJP_VERSION === '2.0';
+    const xmlConfig = isOJPv2 ? OJP_Legacy.XML_ConfigOJPv2 : OJP_Legacy.XML_BuilderConfigOJPv1;
+    
+    const request = OJP_Legacy.TripRequest.initWithRequestMock(this.inputTripRequestXML, xmlConfig, REQUESTOR_REF);
     request.fetchResponse().then(response => {
       if (response.message === 'ERROR') {
         console.error('ERROR fetching OJP response');

--- a/src/app/search-form/input-xml-popover/input-xml-popover.component.ts
+++ b/src/app/search-form/input-xml-popover/input-xml-popover.component.ts
@@ -3,8 +3,7 @@ import { UserTripService } from 'src/app/shared/services/user-trip.service';
 
 import OJP_Legacy from '../../config/ojp-legacy';
 
-import { REQUESTOR_REF } from '../../config/constants';
-import { OJP_VERSION } from '../../config/app-config';
+import { REQUESTOR_REF, OJP_VERSION } from '../../config/constants';
 
 @Component({
   selector: 'input-xml-popover',

--- a/src/app/search-form/journey-point-input/journey-point-input.component.ts
+++ b/src/app/search-form/journey-point-input/journey-point-input.component.ts
@@ -11,6 +11,7 @@ import { LanguageService } from '../../shared/services/language.service'
 import { UserTripService } from '../../shared/services/user-trip.service';
 
 import { SbbErrorStateMatcher } from '@sbb-esta/angular/core';
+import { OJP_VERSION, REQUESTOR_REF } from '../../config/constants';
 
 type MapLocations = Record<OJP_Legacy.LocationType, OJP_Legacy.Location[]>
 type OptionLocationType = [OJP_Legacy.LocationType, string]
@@ -121,9 +122,11 @@ export class JourneyPointInputComponent implements OnInit, OnChanges {
   }
 
   private async fetchJourneyPoints(searchTerm: string) {
-    let stageConfig = this.userTripService.getStageConfig()
+    const stageConfig = this.userTripService.getStageConfig();
+    const isOJPv2 = OJP_VERSION === '2.0';
+    const xmlConfig = isOJPv2 ? OJP_Legacy.XML_ConfigOJPv2 : OJP_Legacy.XML_BuilderConfigOJPv1;
 
-    const request = OJP_Legacy.LocationInformationRequest.initWithLocationName(stageConfig, this.languageService.language, searchTerm, []);
+    const request = OJP_Legacy.LocationInformationRequest.initWithLocationName(stageConfig, this.languageService.language, xmlConfig, REQUESTOR_REF, searchTerm, []);
     request.enableExtensions = this.userTripService.currentAppStage !== 'OJP-SI';
     
     const response = await request.fetchResponse();

--- a/src/app/search-form/journey-point-input/journey-point-input.component.ts
+++ b/src/app/search-form/journey-point-input/journey-point-input.component.ts
@@ -7,11 +7,12 @@ import { SbbErrorStateMatcher } from '@sbb-esta/angular/core';
 
 import OJP_Legacy from '../../config/ojp-legacy';
 
+import { REQUESTOR_REF } from '../../config/constants';
+import { OJP_VERSION } from '../../config/app-config';
+
 import { MapService } from '../../shared/services/map.service';
 import { LanguageService } from '../../shared/services/language.service'
 import { UserTripService } from '../../shared/services/user-trip.service';
-
-import { OJP_VERSION, REQUESTOR_REF } from '../../config/constants';
 
 type MapLocations = Record<OJP_Legacy.LocationType, OJP_Legacy.Location[]>
 type OptionLocationType = [OJP_Legacy.LocationType, string]

--- a/src/app/search-form/journey-point-input/journey-point-input.component.ts
+++ b/src/app/search-form/journey-point-input/journey-point-input.component.ts
@@ -3,6 +3,7 @@ import { Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChange
 import { FormControl, FormGroupDirective, NgForm, Validators } from '@angular/forms';
 
 import { SbbAutocompleteSelectedEvent } from '@sbb-esta/angular/autocomplete';
+import { SbbErrorStateMatcher } from '@sbb-esta/angular/core';
 
 import OJP_Legacy from '../../config/ojp-legacy';
 
@@ -10,7 +11,6 @@ import { MapService } from '../../shared/services/map.service';
 import { LanguageService } from '../../shared/services/language.service'
 import { UserTripService } from '../../shared/services/user-trip.service';
 
-import { SbbErrorStateMatcher } from '@sbb-esta/angular/core';
 import { OJP_VERSION, REQUESTOR_REF } from '../../config/constants';
 
 type MapLocations = Record<OJP_Legacy.LocationType, OJP_Legacy.Location[]>

--- a/src/app/search-form/journey-point-input/journey-point-input.component.ts
+++ b/src/app/search-form/journey-point-input/journey-point-input.component.ts
@@ -7,8 +7,7 @@ import { SbbErrorStateMatcher } from '@sbb-esta/angular/core';
 
 import OJP_Legacy from '../../config/ojp-legacy';
 
-import { REQUESTOR_REF } from '../../config/constants';
-import { OJP_VERSION } from '../../config/app-config';
+import { REQUESTOR_REF, OJP_VERSION } from '../../config/constants';
 
 import { MapService } from '../../shared/services/map.service';
 import { LanguageService } from '../../shared/services/language.service'

--- a/src/app/search-form/search-form.component.ts
+++ b/src/app/search-form/search-form.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit, ViewChild } from '@angular/core';
+import { Router } from '@angular/router';
 import { FormControl } from '@angular/forms';
 import { debounceTime } from 'rxjs';
 
@@ -22,7 +23,7 @@ import { InputXmlPopoverComponent } from './input-xml-popover/input-xml-popover.
 import { EmbedSearchPopoverComponent } from './embed-search-popover/embed-search-popover.component';
 import { DebugXmlPopoverComponent } from './debug-xml-popover/debug-xml-popover.component';
 
-import { Router } from '@angular/router';
+
 import { OJPHelpers } from '../helpers/ojp-helpers';
 
 @Component({

--- a/src/app/search-form/search-form.component.ts
+++ b/src/app/search-form/search-form.component.ts
@@ -19,7 +19,7 @@ import { InputXmlPopoverComponent } from './input-xml-popover/input-xml-popover.
 import { EmbedSearchPopoverComponent } from './embed-search-popover/embed-search-popover.component';
 import { DebugXmlPopoverComponent } from './debug-xml-popover/debug-xml-popover.component';
 
-import { APP_STAGE, APP_STAGEs, DEBUG_LEVEL } from '../config/constants';
+import { APP_STAGE, APP_STAGEs, DEBUG_LEVEL, OJP_VERSION, REQUESTOR_REF } from '../config/constants';
 import { Router } from '@angular/router';
 import { OJPHelpers } from '../helpers/ojp-helpers';
 
@@ -228,7 +228,10 @@ export class SearchFormComponent implements OnInit {
   }
 
   private async initFromMockXML(mockText: string) {
-    const request = OJP_Legacy.TripRequest.initWithResponseMock(mockText);
+    const isOJPv2 = OJP_VERSION === '2.0';
+    const xmlConfig = isOJPv2 ? OJP_Legacy.XML_ConfigOJPv2 : OJP_Legacy.XML_BuilderConfigOJPv1;
+
+    const request = OJP_Legacy.TripRequest.initWithResponseMock(mockText, xmlConfig, REQUESTOR_REF);
     request.fetchResponseWithCallback((response) => {
       if (response.message === 'TripRequest.TripsNo') {
         if (DEBUG_LEVEL === 'DEBUG') {
@@ -302,8 +305,8 @@ export class SearchFormComponent implements OnInit {
     return false
   }
 
-  public handleTapOnSearch() {
-    this.userTripService.updateDepartureDateTime(this.computeFormDepartureDate())
+  public async handleTapOnSearch() {
+    this.userTripService.updateDepartureDateTime(this.computeFormDepartureDate());
 
     const tripRequest = this.computeTripRequest();
     if (tripRequest === null) {
@@ -409,7 +412,10 @@ export class SearchFormComponent implements OnInit {
       const handleCustomXMLResponse = (tripsResponseXML: string) => {
         this.lastCustomTripRequestXML = popover.inputTripRequestXML;
 
-        const request = OJP_Legacy.TripRequest.initWithResponseMock(tripsResponseXML);
+        const isOJPv2 = OJP_VERSION === '2.0';
+        const xmlConfig = isOJPv2 ? OJP_Legacy.XML_ConfigOJPv2 : OJP_Legacy.XML_BuilderConfigOJPv1;
+
+        const request = OJP_Legacy.TripRequest.initWithResponseMock(tripsResponseXML, xmlConfig, REQUESTOR_REF);
         request.fetchResponse().then((response) => {
           popover.inputTripRequestResponseXML = tripsResponseXML;
           dialogRef.close();
@@ -496,6 +502,9 @@ export class SearchFormComponent implements OnInit {
   }
 
   private computeTripRequest() {
+    const isOJPv2 = OJP_VERSION === '2.0';
+    const xmlConfig = isOJPv2 ? OJP_Legacy.XML_ConfigOJPv2 : OJP_Legacy.XML_BuilderConfigOJPv1;
+
     const stageConfig = this.userTripService.getStageConfig();
     const includeLegProjection = true;
     const viaTripLocations = this.userTripService.isViaEnabled ? this.userTripService.viaTripLocations : [];
@@ -503,6 +512,9 @@ export class SearchFormComponent implements OnInit {
     const tripRequest = OJP_Legacy.TripRequest.initWithTripLocationsAndDate(
       stageConfig, 
       this.languageService.language,
+      xmlConfig,
+      REQUESTOR_REF,
+
       this.userTripService.fromTripLocation,
       this.userTripService.toTripLocation,
       this.userTripService.departureDate,

--- a/src/app/search-form/search-form.component.ts
+++ b/src/app/search-form/search-form.component.ts
@@ -9,6 +9,9 @@ import { SbbRadioChange } from '@sbb-esta/angular/radio-button';
 
 import OJP_Legacy from '../config/ojp-legacy';
 
+import { APP_STAGE, APP_STAGEs, DEBUG_LEVEL, REQUESTOR_REF } from '../config/constants';
+import { OJP_VERSION } from '../config/app-config';
+
 import { DateHelpers } from '../helpers/date-helpers';
 
 import { UserTripService } from '../shared/services/user-trip.service'
@@ -19,7 +22,6 @@ import { InputXmlPopoverComponent } from './input-xml-popover/input-xml-popover.
 import { EmbedSearchPopoverComponent } from './embed-search-popover/embed-search-popover.component';
 import { DebugXmlPopoverComponent } from './debug-xml-popover/debug-xml-popover.component';
 
-import { APP_STAGE, APP_STAGEs, DEBUG_LEVEL, OJP_VERSION, REQUESTOR_REF } from '../config/constants';
 import { Router } from '@angular/router';
 import { OJPHelpers } from '../helpers/ojp-helpers';
 

--- a/src/app/search-form/search-form.component.ts
+++ b/src/app/search-form/search-form.component.ts
@@ -9,9 +9,9 @@ import { SbbNotificationToast } from '@sbb-esta/angular/notification-toast';
 import { SbbRadioChange } from '@sbb-esta/angular/radio-button';
 
 import OJP_Legacy from '../config/ojp-legacy';
+import * as OJP_Next from 'ojp-sdk-next';
 
-import { APP_STAGE, APP_STAGEs, DEBUG_LEVEL, REQUESTOR_REF } from '../config/constants';
-import { OJP_VERSION } from '../config/app-config';
+import { APP_STAGE, APP_STAGEs, DEBUG_LEVEL, REQUESTOR_REF, OJP_VERSION } from '../config/constants';
 
 import { DateHelpers } from '../helpers/date-helpers';
 

--- a/src/app/search-form/trip-mode-type/trip-mode-type.component.ts
+++ b/src/app/search-form/trip-mode-type/trip-mode-type.component.ts
@@ -6,18 +6,17 @@ import OJP_Legacy from '../../config/ojp-legacy';
 
 import { UserTripService } from '../../shared/services/user-trip.service';
 import { FormatHelpers } from '../../helpers/format-helpers';
-import { TRIP_REQUEST_DEFAULT_NUMBER_OF_RESULTS } from '../../config/constants';
+import { OJP_VERSION, TRIP_REQUEST_DEFAULT_NUMBER_OF_RESULTS } from '../../config/constants';
 
 interface TripTransportModeData {
   modeType: OJP_Legacy.TripModeType,
   transportModes: OJP_Legacy.IndividualTransportMode[],
 };
 
-const walkTransportMode: OJP_Legacy.IndividualTransportMode = OJP_Legacy.OJP_VERSION === '1.0' ? 'walk' : 'foot'; 
-const carTransportMode: OJP_Legacy.IndividualTransportMode = OJP_Legacy.OJP_VERSION === '1.0' ? 'self-drive-car' : 'car';
+const isOJPv2 = OJP_VERSION === '2.0';
 
-const isOJPv2 = OJP_Legacy.OJP_VERSION === '2.0';
-const walkMode: OJP_Legacy.IndividualTransportMode = isOJPv2 ? 'foot' : 'walk';
+const walkTransportMode: OJP_Legacy.IndividualTransportMode = isOJPv2 ? 'foot' : 'walk'; 
+const carTransportMode: OJP_Legacy.IndividualTransportMode = isOJPv2 ? 'car' : 'self-drive-car';
 
 const appTripTransportModeData: TripTransportModeData[] = [
   {
@@ -48,7 +47,7 @@ const appTripTransportModeData: TripTransportModeData[] = [
   {
     modeType: 'mode_at_end',
     transportModes: [
-      walkMode,
+      walkTransportMode,
       'bicycle_rental',
       'escooter_rental',
       'car_sharing',
@@ -59,7 +58,7 @@ const appTripTransportModeData: TripTransportModeData[] = [
   {
     modeType: 'mode_at_start_end',
     transportModes: [
-      walkMode,
+      walkTransportMode,
       'bicycle_rental',
       'escooter_rental'
     ]
@@ -136,7 +135,7 @@ export class TripModeTypeComponent implements OnInit {
     this.mapPublicTransportModesFilter.water = false;
     this.mapPublicTransportModesFilter.tram = false;
 
-    this.isV1 = OJP_Legacy.OJP_VERSION === '1.0';
+    this.isV1 = OJP_VERSION === '1.0';
 
     this.useRealTimeDataTypes = ['full', 'explanatory', 'none'];
     this.selectedUseRealTimeDataType = this.userTripService.useRealTimeDataType;

--- a/src/app/search-form/trip-mode-type/trip-mode-type.component.ts
+++ b/src/app/search-form/trip-mode-type/trip-mode-type.component.ts
@@ -6,7 +6,9 @@ import OJP_Legacy from '../../config/ojp-legacy';
 
 import { UserTripService } from '../../shared/services/user-trip.service';
 import { FormatHelpers } from '../../helpers/format-helpers';
-import { OJP_VERSION, TRIP_REQUEST_DEFAULT_NUMBER_OF_RESULTS } from '../../config/constants';
+
+import { TRIP_REQUEST_DEFAULT_NUMBER_OF_RESULTS } from '../../config/constants';
+import { OJP_VERSION } from '../../config/app-config';
 
 interface TripTransportModeData {
   modeType: OJP_Legacy.TripModeType,

--- a/src/app/search-form/trip-mode-type/trip-mode-type.component.ts
+++ b/src/app/search-form/trip-mode-type/trip-mode-type.component.ts
@@ -7,8 +7,7 @@ import OJP_Legacy from '../../config/ojp-legacy';
 import { UserTripService } from '../../shared/services/user-trip.service';
 import { FormatHelpers } from '../../helpers/format-helpers';
 
-import { TRIP_REQUEST_DEFAULT_NUMBER_OF_RESULTS } from '../../config/constants';
-import { OJP_VERSION } from '../../config/app-config';
+import { TRIP_REQUEST_DEFAULT_NUMBER_OF_RESULTS, OJP_VERSION } from '../../config/constants';
 
 interface TripTransportModeData {
   modeType: OJP_Legacy.TripModeType,

--- a/src/app/shared/components/web-footer.html
+++ b/src/app/shared/components/web-footer.html
@@ -137,7 +137,7 @@
         © <a href="https://opentransportdata.swiss/en/" target="_blank">Open-Data-Plattform Mobilität Schweiz</a> 2021 - 2025
       </div>
       <div class="d-none d-md-block">
-        Last Update: <a href="{{ this.model.changelogURL }}" target="_blank">{{ this.model.lastUpdate }}</a> - <a href="{{ this.model.githubURL }}" target="_blank">OJP SDK {{ this.model.sdkVersion }}</a>
+        Last Update: <a href="{{ this.model.changelogURL }}" target="_blank">{{ this.model.lastUpdate }}</a> - <a href="{{ this.model.githubURL }}" target="_blank"> {{ this.model.sdkVersionText }}</a>
       </div>
     </div>
   </div>

--- a/src/app/shared/components/web-footer.ts
+++ b/src/app/shared/components/web-footer.ts
@@ -3,8 +3,7 @@ import { Component, OnInit } from '@angular/core';
 import OJP_Legacy from '../../config/ojp-legacy';
 import * as OJP_Next from 'ojp-sdk-next';
 
-import { DEBUG_LEVEL } from '../../config/constants';
-import { OJP_VERSION } from '../../config/app-config';
+import { DEBUG_LEVEL, OJP_VERSION } from '../../config/constants';
 
 type PageModel = {
   sdkVersionText: string,

--- a/src/app/shared/components/web-footer.ts
+++ b/src/app/shared/components/web-footer.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 
 import OJP_Legacy from '../../config/ojp-legacy';
-import { DEBUG_LEVEL } from '../../config/constants';
+import { DEBUG_LEVEL, OJP_VERSION } from '../../config/constants';
 
 type PageModel = {
   sdkVersion: string,
@@ -20,14 +20,15 @@ export class WebFooterComponent implements OnInit {
 
   constructor() {
     const isTopograhicPlaceMapLayerEnabled = DEBUG_LEVEL === 'DEBUG';
+    const isOJPv2 = OJP_VERSION === '2.0';
 
     let changelogURL = 'https://github.com/openTdataCH/ojp-demo-app-src/blob/feature/ojp-v1-beta/CHANGELOG.md';
-    if (OJP_Legacy.OJP_VERSION === '2.0') {
+    if (isOJPv2) {
       changelogURL = 'https://github.com/openTdataCH/ojp-demo-app-src/blob/feature/ojp-v2-beta/CHANGELOG.md';
     }
 
     let githubURL = 'https://github.com/openTdataCH/ojp-js/blob/feature/ojp-v1/CHANGELOG.md';
-    if (OJP_Legacy.OJP_VERSION === '2.0') {
+    if (isOJPv2) {
       githubURL = 'https://github.com/openTdataCH/ojp-js/blob/feature/ojp-v2/CHANGELOG.md';
     }
 

--- a/src/app/shared/components/web-footer.ts
+++ b/src/app/shared/components/web-footer.ts
@@ -2,7 +2,9 @@ import { Component, OnInit } from '@angular/core';
 
 import OJP_Legacy from '../../config/ojp-legacy';
 import * as OJP_Next from 'ojp-sdk-next';
-import { DEBUG_LEVEL, OJP_VERSION } from '../../config/constants';
+
+import { DEBUG_LEVEL } from '../../config/constants';
+import { OJP_VERSION } from '../../config/app-config';
 
 type PageModel = {
   sdkVersionText: string,

--- a/src/app/shared/components/web-footer.ts
+++ b/src/app/shared/components/web-footer.ts
@@ -36,7 +36,7 @@ export class WebFooterComponent implements OnInit {
 
     this.model = {
       sdkVersionText: 'ojp-sdk-legacy: ' + OJP_Legacy.SDK_VERSION + ' - ojp-sdk-next: ' + OJP_Next.SDK_VERSION + ' - OJP API ' + OJP_VERSION,
-      lastUpdate: '4.June 2025',
+      lastUpdate: '6.June 2025',
       isTopograhicPlaceMapLayerEnabled: isTopograhicPlaceMapLayerEnabled,
       changelogURL: changelogURL,
       githubURL: githubURL,

--- a/src/app/shared/components/web-footer.ts
+++ b/src/app/shared/components/web-footer.ts
@@ -1,10 +1,11 @@
 import { Component, OnInit } from '@angular/core';
 
 import OJP_Legacy from '../../config/ojp-legacy';
+import * as OJP_Next from 'ojp-sdk-next';
 import { DEBUG_LEVEL, OJP_VERSION } from '../../config/constants';
 
 type PageModel = {
-  sdkVersion: string,
+  sdkVersionText: string,
   lastUpdate: string,
   isTopograhicPlaceMapLayerEnabled: boolean,
   changelogURL: string,
@@ -33,7 +34,7 @@ export class WebFooterComponent implements OnInit {
     }
 
     this.model = {
-      sdkVersion: OJP_Legacy.SDK_VERSION + ', OJP API ' + OJP_Legacy.OJP_VERSION,
+      sdkVersionText: 'ojp-sdk-legacy: ' + OJP_Legacy.SDK_VERSION + ' - ojp-sdk-next: ' + OJP_Next.SDK_VERSION + ' - OJP API ' + OJP_VERSION,
       lastUpdate: '4.June 2025',
       isTopograhicPlaceMapLayerEnabled: isTopograhicPlaceMapLayerEnabled,
       changelogURL: changelogURL,

--- a/src/app/shared/models/trip-info-result.ts
+++ b/src/app/shared/models/trip-info-result.ts
@@ -2,10 +2,11 @@ import * as OJP_Types from 'ojp-shared-types';
 import * as OJP_Next from 'ojp-sdk-next';
 import OJP_Legacy from '../../config/ojp-legacy';
 
+import { OJP_VERSION } from '../../config/app-config';
+
 import { StopEventType, StopPointCall, StopPointCallType } from '../types/_all';
 import { OJPHelpers } from '../../helpers/ojp-helpers';
 import { JourneyService } from './journey-service';
-import { OJP_VERSION } from '../../config/constants';
 
 const stopEventTypes: StopEventType[] = ['arrival', 'departure'];
 

--- a/src/app/shared/models/trip-info-result.ts
+++ b/src/app/shared/models/trip-info-result.ts
@@ -2,7 +2,7 @@ import * as OJP_Types from 'ojp-shared-types';
 import * as OJP_Next from 'ojp-sdk-next';
 import OJP_Legacy from '../../config/ojp-legacy';
 
-import { OJP_VERSION } from '../../config/app-config';
+import { OJP_VERSION } from '../../config/constants';
 
 import { StopEventType, StopPointCall, StopPointCallType } from '../types/_all';
 import { OJPHelpers } from '../../helpers/ojp-helpers';

--- a/src/app/shared/models/trip-info-result.ts
+++ b/src/app/shared/models/trip-info-result.ts
@@ -5,6 +5,7 @@ import OJP_Legacy from '../../config/ojp-legacy';
 import { StopEventType, StopPointCall, StopPointCallType } from '../types/_all';
 import { OJPHelpers } from '../../helpers/ojp-helpers';
 import { JourneyService } from './journey-service';
+import { OJP_VERSION } from '../../config/constants';
 
 const stopEventTypes: StopEventType[] = ['arrival', 'departure'];
 
@@ -136,7 +137,9 @@ export class TripInfoResult {
     });
 
     const journeyService: JourneyService | null = (() => {
-      if (OJP_Legacy.OJP_VERSION === '1.0') {
+      const isOJPv2 = OJP_VERSION === '2.0';
+
+      if (!isOJPv2) {
         const oldTripInfoResultSchema = firstTripInfoResultSchema as OJP_Types.OJPv1_TripInfoResultStructureSchema;
         const service = JourneyService.initWithLegacyTripInfoResultSchema(oldTripInfoResultSchema);
         return service;

--- a/src/app/shared/services/app.service.ts
+++ b/src/app/shared/services/app.service.ts
@@ -1,6 +1,8 @@
 import { Injectable } from '@angular/core';
 import { Title } from '@angular/platform-browser';
+
 import OJP_Legacy from '../../config/ojp-legacy';
+import { OJP_VERSION } from '../../config/constants';
 
 @Injectable({
   providedIn: 'root',
@@ -16,7 +18,7 @@ export class AppService {
       ];
 
       titleParts.push('BETA');
-      titleParts.push('OJP ' + OJP_Legacy.OJP_VERSION);
+      titleParts.push('OJP ' + OJP_VERSION);
 
       const titleS = titleParts.join(' - ');
 
@@ -35,7 +37,7 @@ export class AppService {
         return 'ojpv1-prod';
       }
 
-      if (OJP_Legacy.OJP_VERSION === '2.0') {
+      if (OJP_VERSION === '2.0') {
         return 'ojpv2-beta'
       } else {
         return 'ojpv1-beta';

--- a/src/app/shared/services/app.service.ts
+++ b/src/app/shared/services/app.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 
-import { OJP_VERSION } from '../../config/app-config';
+import { OJP_VERSION } from '../../config/constants';
 
 @Injectable({
   providedIn: 'root',

--- a/src/app/shared/services/app.service.ts
+++ b/src/app/shared/services/app.service.ts
@@ -1,8 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 
-import OJP_Legacy from '../../config/ojp-legacy';
-import { OJP_VERSION } from '../../config/constants';
+import { OJP_VERSION } from '../../config/app-config';
 
 @Injectable({
   providedIn: 'root',

--- a/src/app/shared/services/user-trip.service.ts
+++ b/src/app/shared/services/user-trip.service.ts
@@ -7,7 +7,9 @@ import * as OJP_Next from 'ojp-sdk-next';
 import * as OJP_Types from 'ojp-shared-types';
 
 import { APP_CONFIG } from '../../config/app-config';
-import { APP_STAGE, DEBUG_LEVEL, DEFAULT_APP_STAGE, OJP_VERSION, REQUESTOR_REF, TRIP_REQUEST_DEFAULT_NUMBER_OF_RESULTS } from '../../config/constants';
+import { APP_STAGE, DEBUG_LEVEL, DEFAULT_APP_STAGE, REQUESTOR_REF, TRIP_REQUEST_DEFAULT_NUMBER_OF_RESULTS } from '../../config/constants';
+import { OJP_VERSION } from '../../config/app-config';
+
 import { MapService } from './map.service';
 import { MapTrip } from '../types/map-geometry-types';
 import { TripData, TripLegData } from '../types/trip';

--- a/src/app/shared/services/user-trip.service.ts
+++ b/src/app/shared/services/user-trip.service.ts
@@ -7,8 +7,7 @@ import * as OJP_Next from 'ojp-sdk-next';
 import * as OJP_Types from 'ojp-shared-types';
 
 import { APP_CONFIG } from '../../config/app-config';
-import { APP_STAGE, DEBUG_LEVEL, DEFAULT_APP_STAGE, REQUESTOR_REF, TRIP_REQUEST_DEFAULT_NUMBER_OF_RESULTS } from '../../config/constants';
-import { OJP_VERSION } from '../../config/app-config';
+import { APP_STAGE, DEBUG_LEVEL, DEFAULT_APP_STAGE, REQUESTOR_REF, TRIP_REQUEST_DEFAULT_NUMBER_OF_RESULTS, OJP_VERSION } from '../../config/constants';
 
 import { MapService } from './map.service';
 import { MapTrip } from '../types/map-geometry-types';

--- a/src/app/shared/services/user-trip.service.ts
+++ b/src/app/shared/services/user-trip.service.ts
@@ -7,7 +7,7 @@ import * as OJP_Next from 'ojp-sdk-next';
 import * as OJP_Types from 'ojp-shared-types';
 
 import { APP_CONFIG } from '../../config/app-config';
-import { APP_STAGE, DEBUG_LEVEL, DEFAULT_APP_STAGE, REQUESTOR_REF, TRIP_REQUEST_DEFAULT_NUMBER_OF_RESULTS } from '../../config/constants';
+import { APP_STAGE, DEBUG_LEVEL, DEFAULT_APP_STAGE, OJP_VERSION, REQUESTOR_REF, TRIP_REQUEST_DEFAULT_NUMBER_OF_RESULTS } from '../../config/constants';
 import { MapService } from './map.service';
 import { MapTrip } from '../types/map-geometry-types';
 import { TripData, TripLegData } from '../types/trip';
@@ -95,6 +95,9 @@ export class UserTripService {
   }
 
   public initDefaults(language: OJP_Legacy.Language) {
+    const isOJPv2 = OJP_VERSION === '2.0';
+    const xmlConfig = isOJPv2 ? OJP_Legacy.XML_ConfigOJPv2 : OJP_Legacy.XML_BuilderConfigOJPv1;
+
     const appStageS = this.queryParams.get('stage') ?? null;
     if (appStageS) {
       const userAppStage = this.computeAppStageFromString(appStageS);
@@ -163,10 +166,10 @@ export class UserTripService {
         });
         promises.push(coordsPromise);
       } else {
-        let locationInformationRequest = OJP_Legacy.LocationInformationRequest.initWithStopPlaceRef(stageConfig, language, stopPlaceRef);
+        let locationInformationRequest = OJP_Legacy.LocationInformationRequest.initWithStopPlaceRef(stageConfig, language, xmlConfig, REQUESTOR_REF, stopPlaceRef);
         // Check if is location name instead of stopId / sloid
         if (typeof stopPlaceRef === 'string' && /^[A-Z]/.test(stopPlaceRef)) {
-          locationInformationRequest = OJP_Legacy.LocationInformationRequest.initWithLocationName(stageConfig, language, stopPlaceRef, []);
+          locationInformationRequest = OJP_Legacy.LocationInformationRequest.initWithLocationName(stageConfig, language, xmlConfig, REQUESTOR_REF, stopPlaceRef, []);
         }
         locationInformationRequest.enableExtensions = this.currentAppStage !== 'OJP-SI';
 
@@ -189,7 +192,7 @@ export class UserTripService {
           bbox.extend(viaLocationFromCoords.geoPosition);
         }
       } else {
-        const stopPlaceLIR = OJP_Legacy.LocationInformationRequest.initWithStopPlaceRef(stageConfig, language, viaKey);
+        const stopPlaceLIR = OJP_Legacy.LocationInformationRequest.initWithStopPlaceRef(stageConfig, language, xmlConfig, REQUESTOR_REF, viaKey);
         stopPlaceLIR.enableExtensions = this.currentAppStage !== 'OJP-SI';
         const stopPlacePromise = stopPlaceLIR.fetchLocations();
         promises.push(stopPlacePromise);
@@ -312,7 +315,10 @@ export class UserTripService {
       const stageConfig = this.getStageConfig();
 
       const ojpRequest: OJP_Legacy.LocationInformationRequest = (() => {
-        const request = OJP_Legacy.LocationInformationRequest.initWithBBOXAndType(stageConfig, language,
+        const isOJPv2 = OJP_VERSION === '2.0';
+        const xmlConfig = isOJPv2 ? OJP_Legacy.XML_ConfigOJPv2 : OJP_Legacy.XML_BuilderConfigOJPv1;
+
+        const request = OJP_Legacy.LocationInformationRequest.initWithBBOXAndType(stageConfig, language, xmlConfig, REQUESTOR_REF,
           bbox.southWest.longitude,
           bbox.northEast.latitude,
           bbox.northEast.longitude,
@@ -539,7 +545,7 @@ export class UserTripService {
   }
 
   private updateLinkedURLs(queryParams: URLSearchParams) {
-    const isOJPv2 = OJP_Legacy.OJP_VERSION === '2.0';
+    const isOJPv2 = OJP_VERSION === '2.0';
 
     const prodQueryParams = new URLSearchParams(queryParams);
     if (isOJPv2) {

--- a/src/app/shared/services/user-trip.service.ts
+++ b/src/app/shared/services/user-trip.service.ts
@@ -952,8 +952,7 @@ export class UserTripService {
     this.updateFares(fareResults);
   }
 
-  public async fetchFaresForTrips(language: OJP_Legacy.Language, trips: OJP_Legacy.Trip[]) {
-
+  public async fetchFaresForTrips(language: OJP_Legacy.Language, trips: OJP_Legacy.Trip[]): Promise<OJP_Types.FareResultSchema[]> {
     const fareHttpConfig = this.getStageConfig('NOVA-INT');
     const ojpSDK_Next = new OJP_Next.SDK(REQUESTOR_REF, fareHttpConfig, language, OJP_Legacy.XML_BuilderConfigOJPv1);
 
@@ -965,9 +964,16 @@ export class UserTripService {
     });
 
     const fareRequest = OJP_Next.FareRequest.initWithOJPv2Trips(tripsV2);
+    const response = await ojpSDK_Next.fetchFareRequestResponse(fareRequest);
 
-    const fareResults = await ojpSDK_Next.fetchFareResults(fareRequest);
-    return fareResults;
+    if (!response.ok) {
+      console.log('ERROR: fetchFareRequestResponse');
+      console.log(response);
+      
+      return [];
+    }
+
+    return response.value.fareResult;
   }
 
   public hasPublicTransport(): boolean {

--- a/src/app/station-board/input/station-board-input.component.ts
+++ b/src/app/station-board/input/station-board-input.component.ts
@@ -5,10 +5,11 @@ import { debounceTime, distinctUntilChanged } from 'rxjs/operators'
 import { SbbAutocompleteSelectedEvent, SbbAutocompleteTrigger } from '@sbb-esta/angular/autocomplete';
 
 import OJP_Legacy from '../../config/ojp-legacy';
+import { REQUESTOR_REF } from '../../config/constants';
+import { OJP_VERSION } from '../../config/app-config';
 
 import { UserTripService } from '../../shared/services/user-trip.service';
 import { LanguageService } from '../../shared/services/language.service';
-import { OJP_VERSION, REQUESTOR_REF } from '../../config/constants';
 
 interface StopLookup {
   stopPlaceRef: string

--- a/src/app/station-board/input/station-board-input.component.ts
+++ b/src/app/station-board/input/station-board-input.component.ts
@@ -8,6 +8,7 @@ import OJP_Legacy from '../../config/ojp-legacy';
 
 import { UserTripService } from '../../shared/services/user-trip.service';
 import { LanguageService } from '../../shared/services/language.service';
+import { OJP_VERSION, REQUESTOR_REF } from '../../config/constants';
 
 interface StopLookup {
   stopPlaceRef: string
@@ -96,10 +97,12 @@ export class StationBoardInputComponent implements OnInit {
 
   private async fetchLookupLocations(searchTerm: string) {
     this.isBusySearching = true;
+    const isOJPv2 = OJP_VERSION === '2.0';
+    const xmlConfig = isOJPv2 ? OJP_Legacy.XML_ConfigOJPv2 : OJP_Legacy.XML_BuilderConfigOJPv1;
 
     const restrictionType: OJP_Legacy.RestrictionType = 'stop';
     const stageConfig = this.userTripService.getStageConfig();
-    const locationInformationRequest = OJP_Legacy.LocationInformationRequest.initWithLocationName(stageConfig, this.languageService.language, searchTerm, [restrictionType]);
+    const locationInformationRequest = OJP_Legacy.LocationInformationRequest.initWithLocationName(stageConfig, this.languageService.language, xmlConfig, REQUESTOR_REF, searchTerm, [restrictionType]);
     locationInformationRequest.enableExtensions = this.userTripService.currentAppStage !== 'OJP-SI';
 
     const response = await locationInformationRequest.fetchResponse();
@@ -208,12 +211,18 @@ export class StationBoardInputComponent implements OnInit {
     const bbox_E = position.coords.longitude + bbox_width / 2;
     const bbox_N = position.coords.latitude + bbox_height / 2;
     const bbox_S = position.coords.latitude - bbox_height / 2;
+
+    const isOJPv2 = OJP_VERSION === '2.0';
+    const xmlConfig = isOJPv2 ? OJP_Legacy.XML_ConfigOJPv2 : OJP_Legacy.XML_BuilderConfigOJPv1;
     
     const stageConfig = this.userTripService.getStageConfig();
 
     const request = OJP_Legacy.LocationInformationRequest.initWithBBOXAndType(
       stageConfig,
       this.languageService.language,
+      xmlConfig,
+      REQUESTOR_REF,
+
       bbox_W, bbox_N, bbox_E, bbox_S,
       ['stop'],
       300,

--- a/src/app/station-board/input/station-board-input.component.ts
+++ b/src/app/station-board/input/station-board-input.component.ts
@@ -5,8 +5,7 @@ import { debounceTime, distinctUntilChanged } from 'rxjs/operators'
 import { SbbAutocompleteSelectedEvent, SbbAutocompleteTrigger } from '@sbb-esta/angular/autocomplete';
 
 import OJP_Legacy from '../../config/ojp-legacy';
-import { REQUESTOR_REF } from '../../config/constants';
-import { OJP_VERSION } from '../../config/app-config';
+import { REQUESTOR_REF, OJP_VERSION } from '../../config/constants';
 
 import { UserTripService } from '../../shared/services/user-trip.service';
 import { LanguageService } from '../../shared/services/language.service';

--- a/src/app/station-board/search/custom-stop-event-xml-popover/custom-stop-event-xml-popover.component.ts
+++ b/src/app/station-board/search/custom-stop-event-xml-popover/custom-stop-event-xml-popover.component.ts
@@ -2,6 +2,7 @@ import { Component, EventEmitter, Output } from '@angular/core';
 import { UserTripService } from 'src/app/shared/services/user-trip.service';
 
 import OJP_Legacy from '../../../config/ojp-legacy';
+import { OJP_VERSION, REQUESTOR_REF } from '../../../config/constants';
 
 @Component({
   selector: 'custom-stop-event-popover',
@@ -24,10 +25,12 @@ export class CustomStopEventXMLPopoverComponent {
   }
 
   public parseCustomRequestXML() {
-    this.isRunningRequest = true
+    this.isRunningRequest = true;
+    const isOJPv2 = OJP_VERSION === '2.0';
+    const xmlConfig = isOJPv2 ? OJP_Legacy.XML_ConfigOJPv2 : OJP_Legacy.XML_BuilderConfigOJPv1;
 
     const stageConfig = this.userTripService.getStageConfig();
-    const request = OJP_Legacy.StopEventRequest.initWithRequestMock(this.customRequestXMLs, stageConfig);
+    const request = OJP_Legacy.StopEventRequest.initWithRequestMock(this.customRequestXMLs, stageConfig, xmlConfig, REQUESTOR_REF);
     request.fetchResponse().then(response => {
       this.isRunningRequest = false;
       const responseXML = request.requestInfo.responseXML;

--- a/src/app/station-board/search/custom-stop-event-xml-popover/custom-stop-event-xml-popover.component.ts
+++ b/src/app/station-board/search/custom-stop-event-xml-popover/custom-stop-event-xml-popover.component.ts
@@ -2,8 +2,8 @@ import { Component, EventEmitter, Output } from '@angular/core';
 import { UserTripService } from 'src/app/shared/services/user-trip.service';
 
 import OJP_Legacy from '../../../config/ojp-legacy';
-import { OJP_VERSION } from '../../../config/app-config';
-import { REQUESTOR_REF } from '../../../config/constants';
+
+import { REQUESTOR_REF, OJP_VERSION } from '../../../config/constants';
 
 @Component({
   selector: 'custom-stop-event-popover',

--- a/src/app/station-board/search/custom-stop-event-xml-popover/custom-stop-event-xml-popover.component.ts
+++ b/src/app/station-board/search/custom-stop-event-xml-popover/custom-stop-event-xml-popover.component.ts
@@ -2,7 +2,8 @@ import { Component, EventEmitter, Output } from '@angular/core';
 import { UserTripService } from 'src/app/shared/services/user-trip.service';
 
 import OJP_Legacy from '../../../config/ojp-legacy';
-import { OJP_VERSION, REQUESTOR_REF } from '../../../config/constants';
+import { OJP_VERSION } from '../../../config/app-config';
+import { REQUESTOR_REF } from '../../../config/constants';
 
 @Component({
   selector: 'custom-stop-event-popover',

--- a/src/app/station-board/search/station-board-search.component.ts
+++ b/src/app/station-board/search/station-board-search.component.ts
@@ -5,9 +5,10 @@ import { SbbExpansionPanel } from '@sbb-esta/angular/accordion';
 import { SbbDialog } from '@sbb-esta/angular/dialog';
 import { SbbNotificationToast } from '@sbb-esta/angular/notification-toast';
 
-import * as GeoJSON from 'geojson'
+import * as GeoJSON from 'geojson';
 import OJP_Legacy from '../../config/ojp-legacy';
-import { OJP_VERSION } from '../../config/app-config';
+
+import { APP_STAGE, APP_STAGEs, DEBUG_LEVEL, DEFAULT_APP_STAGE, REQUESTOR_REF, OJP_VERSION } from '../../config/constants';
 
 import { OJPHelpers } from '../../helpers/ojp-helpers';
 
@@ -20,8 +21,6 @@ import { StationBoardInputComponent } from '../input/station-board-input.compone
 import { DebugXmlPopoverComponent } from '../../search-form/debug-xml-popover/debug-xml-popover.component';
 import { CustomStopEventXMLPopoverComponent } from './custom-stop-event-xml-popover/custom-stop-event-xml-popover.component';
 import { EmbedStationBoardPopoverComponent } from './embed-station-board-popover/embed-station-board-popover.component';
-
-import { APP_STAGE, APP_STAGEs, DEBUG_LEVEL, DEFAULT_APP_STAGE, REQUESTOR_REF } from '../../config/constants'
 
 type URLType = 'prodv1' | 'betav1' | 'betav2' | 'beta';
 

--- a/src/app/station-board/search/station-board-search.component.ts
+++ b/src/app/station-board/search/station-board-search.component.ts
@@ -7,6 +7,7 @@ import { SbbNotificationToast } from '@sbb-esta/angular/notification-toast';
 
 import * as GeoJSON from 'geojson'
 import OJP_Legacy from '../../config/ojp-legacy';
+import { OJP_VERSION } from '../../config/app-config';
 
 import { OJPHelpers } from '../../helpers/ojp-helpers';
 
@@ -20,7 +21,7 @@ import { DebugXmlPopoverComponent } from '../../search-form/debug-xml-popover/de
 import { CustomStopEventXMLPopoverComponent } from './custom-stop-event-xml-popover/custom-stop-event-xml-popover.component';
 import { EmbedStationBoardPopoverComponent } from './embed-station-board-popover/embed-station-board-popover.component';
 
-import { APP_STAGE, APP_STAGEs, DEBUG_LEVEL, DEFAULT_APP_STAGE, OJP_VERSION, REQUESTOR_REF } from '../../config/constants'
+import { APP_STAGE, APP_STAGEs, DEBUG_LEVEL, DEFAULT_APP_STAGE, REQUESTOR_REF } from '../../config/constants'
 
 type URLType = 'prodv1' | 'betav1' | 'betav2' | 'beta';
 

--- a/src/app/station-board/search/station-board-search.component.ts
+++ b/src/app/station-board/search/station-board-search.component.ts
@@ -20,7 +20,7 @@ import { DebugXmlPopoverComponent } from '../../search-form/debug-xml-popover/de
 import { CustomStopEventXMLPopoverComponent } from './custom-stop-event-xml-popover/custom-stop-event-xml-popover.component';
 import { EmbedStationBoardPopoverComponent } from './embed-station-board-popover/embed-station-board-popover.component';
 
-import { APP_STAGE, APP_STAGEs, DEBUG_LEVEL, DEFAULT_APP_STAGE } from '../../config/constants'
+import { APP_STAGE, APP_STAGEs, DEBUG_LEVEL, DEFAULT_APP_STAGE, OJP_VERSION, REQUESTOR_REF } from '../../config/constants'
 
 type URLType = 'prodv1' | 'betav1' | 'betav2' | 'beta';
 
@@ -105,7 +105,7 @@ export class StationBoardSearchComponent implements OnInit {
     this.headerText = this.stationBoardType;
     this.showURLS = DEBUG_LEVEL === 'DEBUG';
 
-    this.isV1 = OJP_Legacy.OJP_VERSION === '1.0';
+    this.isV1 = OJP_VERSION === '1.0';
     this.useRealTimeDataTypes = ['full', 'explanatory', 'none'];
   }
 
@@ -317,7 +317,7 @@ export class StationBoardSearchComponent implements OnInit {
   }
 
   private updateLinkedURLs(queryParams: URLSearchParams) {
-    const isOJPv2 = OJP_Legacy.OJP_VERSION === '2.0';
+    const isOJPv2 = OJP_VERSION === '2.0';
 
     const prodQueryParams = new URLSearchParams(queryParams);
     if (isOJPv2) {
@@ -359,7 +359,10 @@ export class StationBoardSearchComponent implements OnInit {
   }
 
   private initFromMockXML(mockText: string) {
-    const request = OJP_Legacy.StopEventRequest.initWithMock(mockText);
+    const isOJPv2 = OJP_VERSION === '2.0';
+    const xmlConfig = isOJPv2 ? OJP_Legacy.XML_ConfigOJPv2 : OJP_Legacy.XML_BuilderConfigOJPv1;
+
+    const request = OJP_Legacy.StopEventRequest.initWithMock(mockText, xmlConfig, REQUESTOR_REF);
     request.fetchResponse().then(response => {
       if (response.stopEvents.length > 0) {
         const stopEvent = response.stopEvents[0];
@@ -374,10 +377,13 @@ export class StationBoardSearchComponent implements OnInit {
   }
 
   private computeStopEventRequest(stopPlaceRef: string): OJP_Legacy.StopEventRequest {
+    const isOJPv2 = OJP_VERSION === '2.0';
+    const xmlConfig = isOJPv2 ? OJP_Legacy.XML_ConfigOJPv2 : OJP_Legacy.XML_BuilderConfigOJPv1;
+
     const stopEventType: OJP_Legacy.StopEventType = this.stationBoardType === 'Arrivals' ? 'arrival' : 'departure'
     const stopEventDate = this.computeStopBoardDate();
     const appStageConfig = this.userTripService.getStageConfig();
-    const stopEventRequest = OJP_Legacy.StopEventRequest.initWithStopPlaceRef(appStageConfig, this.languageService.language, stopPlaceRef, stopEventType, stopEventDate);
+    const stopEventRequest = OJP_Legacy.StopEventRequest.initWithStopPlaceRef(appStageConfig, this.languageService.language, xmlConfig, REQUESTOR_REF, stopPlaceRef, stopEventType, stopEventDate);
     stopEventRequest.useRealTimeDataType = this.userTripService.useRealTimeDataType;
     
     // for debug XML dialog
@@ -402,8 +408,11 @@ export class StationBoardSearchComponent implements OnInit {
   }
 
   private async lookupStopPlaceRef(stopPlaceRef: string) {
+    const isOJPv2 = OJP_VERSION === '2.0';
+    const xmlConfig = isOJPv2 ? OJP_Legacy.XML_ConfigOJPv2 : OJP_Legacy.XML_BuilderConfigOJPv1;
+
     const stageConfig = this.userTripService.getStageConfig();
-    const locationInformationRequest = OJP_Legacy.LocationInformationRequest.initWithStopPlaceRef(stageConfig, this.languageService.language, stopPlaceRef);
+    const locationInformationRequest = OJP_Legacy.LocationInformationRequest.initWithStopPlaceRef(stageConfig, this.languageService.language, xmlConfig, REQUESTOR_REF, stopPlaceRef);
     locationInformationRequest.enableExtensions = this.userTripService.currentAppStage !== 'OJP-SI';
 
     const response = await locationInformationRequest.fetchResponse();
@@ -535,7 +544,10 @@ export class StationBoardSearchComponent implements OnInit {
     this.currentRequestInfo.responseDateTime = new Date();
     this.currentRequestInfo.responseXML = responseXML;
 
-    const request = OJP_Legacy.StopEventRequest.initWithMock(responseXML);
+    const isOJPv2 = OJP_VERSION === '2.0';
+    const xmlConfig = isOJPv2 ? OJP_Legacy.XML_ConfigOJPv2 : OJP_Legacy.XML_BuilderConfigOJPv1;
+
+    const request = OJP_Legacy.StopEventRequest.initWithMock(responseXML, xmlConfig, REQUESTOR_REF);
     request.fetchResponse().then(response => {
       const stopEvents = response.stopEvents;
 

--- a/src/app/trip-info/search/trip-info-search.component.ts
+++ b/src/app/trip-info/search/trip-info-search.component.ts
@@ -7,8 +7,7 @@ import { SbbNotificationToast } from '@sbb-esta/angular/notification-toast';
 import OJP_Legacy from '../../config/ojp-legacy';
 import * as OJP_Next from 'ojp-sdk-next';
 
-import { APP_STAGE, APP_STAGEs, REQUESTOR_REF } from '../../config/constants'
-import { OJP_VERSION } from '../../config/app-config';
+import { APP_STAGE, APP_STAGEs, REQUESTOR_REF, OJP_VERSION } from '../../config/constants';
 
 import { UserTripService } from '../../shared/services/user-trip.service';
 import { TripInfoService } from '../trip-info.service';

--- a/src/app/trip-info/search/trip-info-search.component.ts
+++ b/src/app/trip-info/search/trip-info-search.component.ts
@@ -7,7 +7,8 @@ import { SbbNotificationToast } from '@sbb-esta/angular/notification-toast';
 import OJP_Legacy from '../../config/ojp-legacy';
 import * as OJP_Next from 'ojp-sdk-next';
 
-import { APP_STAGE, APP_STAGEs, OJP_VERSION, REQUESTOR_REF } from '../../config/constants'
+import { APP_STAGE, APP_STAGEs, REQUESTOR_REF } from '../../config/constants'
+import { OJP_VERSION } from '../../config/app-config';
 
 import { UserTripService } from '../../shared/services/user-trip.service';
 import { TripInfoService } from '../trip-info.service';

--- a/src/app/trip-info/search/trip-info-search.component.ts
+++ b/src/app/trip-info/search/trip-info-search.component.ts
@@ -7,7 +7,7 @@ import { SbbNotificationToast } from '@sbb-esta/angular/notification-toast';
 import OJP_Legacy from '../../config/ojp-legacy';
 import * as OJP_Next from 'ojp-sdk-next';
 
-import { APP_STAGE, APP_STAGEs, REQUESTOR_REF } from '../../config/constants'
+import { APP_STAGE, APP_STAGEs, OJP_VERSION, REQUESTOR_REF } from '../../config/constants'
 
 import { UserTripService } from '../../shared/services/user-trip.service';
 import { TripInfoService } from '../trip-info.service';
@@ -264,8 +264,11 @@ export class TripInfoSearchComponent implements OnInit {
   }
 
   private createOJP_SDK_Instance(): OJP_Next.SDK {
+    const isOJPv2 = OJP_VERSION === '2.0';
+    const xmlConfig = isOJPv2 ? OJP_Legacy.XML_ConfigOJPv2 : OJP_Legacy.XML_BuilderConfigOJPv1;
+
     const stageConfig = this.userTripService.getStageConfig();    
-    const sdk = new OJP_Next.SDK(REQUESTOR_REF, stageConfig, this.languageService.language, OJP_Legacy.XML_BuilderConfig);
+    const sdk = new OJP_Next.SDK(REQUESTOR_REF, stageConfig, this.languageService.language, xmlConfig);
     return sdk;
   }
 }


### PR DESCRIPTION
- adds logic to compute `OJP_VERSION`: `1.0` or `2.0`, based on user params, path and host. Default is `2.0`
- use [ojp-sdk-legacy](https://www.npmjs.com/package/ojp-sdk-legacy) for OJP SDK and propagate the `OJP_VERSION`, `REQUESTOR_REF` when using it