### PR TITLE
Improves shared mobility legs

### DIFF
--- a/src/app/config/map-colors.ts
+++ b/src/app/config/map-colors.ts
@@ -19,7 +19,7 @@ export const MapLegLineTypeColor: Record<TripLegLineType, string> = {
   Funicular: '#8B4513',
   Walk: '#009933',
   'Self-Drive Car': '#ff004f',
-  'Shared Mobility': '#32CD32',
+  'Shared Mobility': '#871282',
   Guidance: '#6f0000',
   Transfer: '#088F8F',
   Water: '#005AB3',

--- a/src/app/shared/controllers/trip-geo-controller.ts
+++ b/src/app/shared/controllers/trip-geo-controller.ts
@@ -383,6 +383,24 @@ export class TripLegGeoController {
 
     const isCar = OJPHelpers.isCar(continuousLeg);
 
+    const lineType: TripLegLineType = (() => {
+      if (continuousLeg.legTransportMode === null) {
+        return 'Guidance';
+      }
+
+      const sharedMobilityModes: OJP_Legacy.IndividualTransportMode[] = ['cycle', 'escooter_rental', 'bicycle_rental', 'charging_station'];
+      if (sharedMobilityModes.includes(continuousLeg.legTransportMode)) {
+        return 'Shared Mobility';
+      }
+
+      const autoModes: OJP_Legacy.IndividualTransportMode[] = ['car', 'car_sharing', 'self-drive-car', 'taxi', 'others-drive-car', 'car-shuttle-train', 'car-ferry'];
+      if (autoModes.includes(continuousLeg.legTransportMode)) {
+        return 'Self-Drive Car';
+      }
+
+      return 'Guidance';
+    })();
+
     continuousLeg.pathGuidance?.sections.forEach((pathGuidanceSection, guidanceIDx) => {
       const feature = pathGuidanceSection.trackSection?.linkProjection?.asGeoJSONFeature();
       if (!feature?.properties) {
@@ -392,7 +410,6 @@ export class TripLegGeoController {
       const drawType: TripLegDrawType = 'LegLine';
       feature.properties[TripLegPropertiesEnum.DrawType] = drawType;
 
-      const lineType: TripLegLineType = isCar ? 'Self-Drive Car' : 'Guidance';
       feature.properties[TripLegPropertiesEnum.LineType] = lineType;
 
       feature.properties['PathGuidanceSection.idx'] = guidanceIDx;

--- a/src/app/shared/controllers/trip-geo-controller.ts
+++ b/src/app/shared/controllers/trip-geo-controller.ts
@@ -405,17 +405,19 @@ export class TripLegGeoController {
       features.push(feature);
     });
 
-    continuousLeg.legTrack?.trackSections.forEach(trackSection => {
-      const feature = trackSection.linkProjection?.asGeoJSONFeature()
-      if (feature?.properties) {
-        const drawType: TripLegDrawType = 'LegLine';
-        feature.properties[TripLegPropertiesEnum.DrawType] = drawType;
+    if (features.length === 0) {
+      continuousLeg.legTrack?.trackSections.forEach(trackSection => {
+        const feature = trackSection.linkProjection?.asGeoJSONFeature()
+        if (feature?.properties) {
+          const drawType: TripLegDrawType = 'LegLine';
+          feature.properties[TripLegPropertiesEnum.DrawType] = drawType;
 
-        feature.properties[TripLegPropertiesEnum.LineType] = this.computeLegLineType();
+          feature.properties[TripLegPropertiesEnum.LineType] = this.computeLegLineType();
 
-        features.push(feature);
-      }
-    });
+          features.push(feature);
+        }
+      });
+    }
 
     if (features.length === 0) {
       const feature = this.computeBeelineFeature();


### PR DESCRIPTION
- different color for SharedMobility
- use LegProjection geo only if guidanceGeo is empty
- catch more cases when drawing continuous legs

<img width="1184" height="600" alt="image" src="https://github.com/user-attachments/assets/3887580b-a723-48bf-a695-778a1d26fe68" />
