### PR TITLE
Add departure data from leg2 to leg1 in mergeTimedLegs

### DIFF
--- a/src/app/helpers/ojp-helpers.ts
+++ b/src/app/helpers/ojp-helpers.ts
@@ -816,6 +816,7 @@ export class OJPHelpers {
   private static mergeTimedLegs(leg1: OJP_Legacy.TripTimedLeg, leg2: OJP_Legacy.TripTimedLeg) {
     let newLegIntermediatePoints = leg1.intermediateStopPoints.slice();
     leg1.toStopPoint.stopPointType = 'Intermediate';
+    leg1.toStopPoint.departureData = leg2.fromStopPoint.departureData;
     newLegIntermediatePoints.push(leg1.toStopPoint);
     newLegIntermediatePoints = newLegIntermediatePoints.concat(leg2.intermediateStopPoints.slice());
 


### PR DESCRIPTION
before (online version)
<img width="485" height="507" alt="grafik" src="https://github.com/user-attachments/assets/51e02fb6-8dbb-4f04-90f0-fb335ca6c0bc" />

after (only tested with MOTIS locally)
<img width="485" height="479" alt="grafik" src="https://github.com/user-attachments/assets/d02c8b65-363c-4fc7-905b-c71b55a30a1c" />

(note: the departure time is not missing anymore at the stop where the two trains are interlined)
