### PR TITLE
Improve shapes provider API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ OJP-Demo URL: https://opentdatach.github.io/ojp-demo-app/
 ----
 
 13.August 2026
-- Improve leg endpoint names - [PR #397](https://github.com/openTdataCH/ojp-demo-app-src/pull/397)
+- Improve leg endpoint names - [geOps with SLOID-LegProjection #377](https://github.com/openTdataCH/ojp-demo-app-src/issues/377), [PR #397](https://github.com/openTdataCH/ojp-demo-app-src/pull/397)
   - unify handling of endpoint names for Continuous / Transfer legs
 - Improve shapes provider - [PR #398](Improve shapes provider API- #398)
   - use sloids whenever is possible

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ OJP-Demo URL: https://opentdatach.github.io/ojp-demo-app/
 13.August 2026
 - Improve leg endpoint names - [PR #397](https://github.com/openTdataCH/ojp-demo-app-src/pull/397)
   - unify handling of endpoint names for Continuous / Transfer legs
+- Improve shapes provider - [PR #398](Improve shapes provider API- #398)
+  - use sloids whenever is possible
+  - use `atlas=true` for TimedLeg with exclusive sloids
 
 30.July 2026
 - Improves ShapesProvider - [geOps with SLOID-LegProjection

--- a/src/app/shared/services/shape-provider.service.ts
+++ b/src/app/shared/services/shape-provider.service.ts
@@ -300,27 +300,18 @@ export class ShapeProviderService {
     const apiURL = (() => {
       const viaParam: string = (() => {
         viaParts.forEach(viaPart => {
-          if (useStopIds) {
-            let viaKeyPart = '!' + viaPart.stopId;
-            if (viaPart.platform !== null) {
-              // viaKeyPart = viaKeyPart + '$' + viaPart.platform;
-            }
-            apiViaParts.push(viaKeyPart);
-          } else {
-            // in API the hops are in lat,long format
-            let viaKeyPart = viaPart.geoPosition.latitude + ',' + viaPart.geoPosition.longitude;
-
-            if (viaPart.floor !== null) {
-              viaKeyPart = viaKeyPart + '$' + viaPart.floor;
+          const viaKeyPart = (() => {
+            if (viaPart.stopId) {
+              const viaStopId = '!' + viaPart.stopId;
+              return viaStopId;
             } else {
-              // TODO: platform works ONLY with !DIDOK
-              // if (viaPart.platform !== null) {
-              //   viaKeyPart = '@' + viaKeyPart + '$' + viaPart.platform;
-              // }
+              // in API the hops are in lat,long format - DIFFERENT than in the demo app
+              const viaKeyPart = viaPart.geoPosition.latitude + ',' + viaPart.geoPosition.longitude;
+              return viaKeyPart;
             }
+          })();
 
-            apiViaParts.push(viaKeyPart);
-          }
+          apiViaParts.push(viaKeyPart);
         });
 
         const param = apiViaParts.join('|');
@@ -351,7 +342,6 @@ export class ShapeProviderService {
         const floorValues = endpointTypes.map(endpointType => {
           const defFloorValue = '0';
 
-
           const isFrom = endpointType === 'From';
           const viaPart = isFrom ? viaParts[0] : viaParts[viaParts.length - 1];
 
@@ -371,19 +361,16 @@ export class ShapeProviderService {
       const viaParam: string = (() => {
         const viaKeyParts: string[] = [];
         viaParts.forEach(viaPart => {
-          if (useStopIds) {
-            const viaKeyPart = '!' + viaPart.stopId;
-            viaKeyParts.push(viaKeyPart);
-          } else {
-            // in GUI the hops are in long,lat format - also no @ prefix when we have stops
-            let viaKeyPart = viaPart.geoPosition.longitude + ',' + viaPart.geoPosition.latitude;
-
-            // TODO: PLATFORM doesnt work with coords, only with !DIDOK|platform
-            // if (viaPart.platform !== null) {
-            //   viaKeyPart = viaKeyPart + '$' + viaPart.platform;
-            // }
-            viaKeyParts.push(viaKeyPart);
-          }
+          const viaKeyPart = (() => {
+            if (viaPart.stopId) {
+              const viaStopId = '!' + viaPart.stopId;
+              return viaStopId;
+            } else {
+              const viaCoords = viaPart.geoPosition.longitude + ',' + viaPart.geoPosition.latitude;
+              return viaCoords;
+            }
+          })();
+          viaKeyParts.push(viaKeyPart);
         });
 
         const param = viaKeyParts.join('|');

--- a/src/app/shared/services/shape-provider.service.ts
+++ b/src/app/shared/services/shape-provider.service.ts
@@ -327,6 +327,7 @@ export class ShapeProviderService {
         return param;
       })();
 
+      // https://developer.geops.io/apis/routing
       const url = new URL(apiConfig['url']);
       url.searchParams.set('via', viaParam);
       url.searchParams.set('mot', motType);

--- a/src/app/shared/services/shape-provider.service.ts
+++ b/src/app/shared/services/shape-provider.service.ts
@@ -293,7 +293,7 @@ export class ShapeProviderService {
     })();
 
     const viaPartsStopIds = viaParts.filter(el => el.stopId !== null);
-    const useStopIds = (motType !== 'foot') && (viaParts.length >= 2) && (viaParts.length === viaPartsStopIds.length);
+    const useAtlas = (motType !== 'foot') && (viaParts.length >= 2) && (viaParts.length === viaPartsStopIds.length);
 
     const apiViaParts: string[] = [];
 
@@ -322,6 +322,10 @@ export class ShapeProviderService {
       const url = new URL(apiConfig['url']);
       url.searchParams.set('via', viaParam);
       url.searchParams.set('mot', motType);
+
+      if (useAtlas) {
+        url.searchParams.set('atlas', 'true');
+      }
 
       return url.toString();
     })();


### PR DESCRIPTION
- use sloids whenever is possible
- use `atlas=true` for TimedLeg with exclusive sloids